### PR TITLE
chore: add render tests

### DIFF
--- a/render_test.go
+++ b/render_test.go
@@ -1,6 +1,366 @@
 package sawchain_test
 
-// TODO: test RenderSingle
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/guidewire-oss/sawchain"
+	"github.com/guidewire-oss/sawchain/internal/testutil"
+	"github.com/guidewire-oss/sawchain/internal/util"
+)
+
+var _ = Describe("RenderSingle", func() {
+	type testCase struct {
+		globalBindings      map[string]any
+		methodArgs          []interface{}
+		expectedObj         client.Object
+		expectedFailureLogs []string
+	}
+	DescribeTable("rendering single objects",
+		func(tc testCase) {
+			// Initialize Sawchain
+			t := &MockT{TB: GinkgoTB()}
+			sc := sawchain.New(t, testutil.NewStandardFakeClient(), tc.globalBindings)
+
+			// Test RenderSingle
+			var returnedObj client.Object
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				returnedObj = sc.RenderSingle(tc.methodArgs...)
+			}()
+			<-done
+
+			// Verify failure
+			if len(tc.expectedFailureLogs) > 0 {
+				Expect(t.Failed()).To(BeTrue(), "expected failure")
+				for _, expectedLog := range tc.expectedFailureLogs {
+					Expect(t.ErrorLogs).To(ContainElement(ContainSubstring(expectedLog)))
+				}
+			} else {
+				Expect(t.Failed()).To(BeFalse(), "expected no failure")
+			}
+
+			if tc.expectedObj != nil {
+				// Verify returned object
+				Expect(returnedObj).To(Equal(tc.expectedObj), "incorrect returned object")
+
+				// Verify provided object
+				for _, arg := range tc.methodArgs {
+					if providedObj, ok := util.AsObject(arg); ok {
+						Expect(providedObj).To(Equal(tc.expectedObj), "incorrect provided object")
+						break
+					}
+				}
+			}
+		},
+
+		// Success cases - return mode
+		Entry("should render template with bindings (return mode)", testCase{
+			methodArgs: []interface{}{
+				`
+				apiVersion: v1
+				kind: ConfigMap
+				metadata:
+				  name: ($name)
+				  namespace: ($namespace)
+				data:
+				  key: value
+				`,
+				map[string]any{"name": "test-cm", "namespace": "default"},
+			},
+			expectedObj: testutil.NewConfigMap("test-cm", "default", map[string]string{"key": "value"}),
+		}),
+
+		Entry("should render template with multiple binding maps (return mode)", testCase{
+			globalBindings: map[string]any{"namespace": "test-ns"},
+			methodArgs: []interface{}{
+				`
+				apiVersion: v1
+				kind: ConfigMap
+				metadata:
+				  name: ($name)
+				  namespace: ($namespace)
+				data:
+				  key: ($value)
+				`,
+				map[string]any{"name": "test-cm", "value": "first"},
+				map[string]any{"value": "override"},
+			},
+			expectedObj: testutil.NewConfigMap("test-cm", "test-ns", map[string]string{"key": "override"}),
+		}),
+
+		Entry("should return typed object when scheme supports it", testCase{
+			methodArgs: []interface{}{
+				`
+				apiVersion: v1
+				kind: ConfigMap
+				metadata:
+				  name: test-cm
+				  namespace: default
+				data:
+				  key: value
+				`,
+			},
+			expectedObj: testutil.NewConfigMap("test-cm", "default", map[string]string{"key": "value"}),
+		}),
+
+		Entry("should return unstructured object when scheme doesn't support type", testCase{
+			methodArgs: []interface{}{
+				`
+				apiVersion: example.com/v1
+				kind: TestResource
+				metadata:
+				  name: test-cr
+				  namespace: default
+				data: test-data
+				status:
+				  conditions: []
+				`,
+			},
+			expectedObj: testutil.NewUnstructuredTestResource("test-cr", "default", "test-data"),
+		}),
+
+		// Success cases - populate mode
+		Entry("should populate typed object", testCase{
+			methodArgs: []interface{}{
+				&corev1.ConfigMap{},
+				`
+				apiVersion: v1
+				kind: ConfigMap
+				metadata:
+				  name: test-cm
+				  namespace: default
+				data:
+				  key: value
+				`,
+			},
+			expectedObj: testutil.NewConfigMap("test-cm", "default", map[string]string{"key": "value"}),
+		}),
+
+		Entry("should populate unstructured object", testCase{
+			methodArgs: []interface{}{
+				&unstructured.Unstructured{},
+				`
+				apiVersion: v1
+				kind: ConfigMap
+				metadata:
+				  name: test-cm
+				  namespace: default
+				data:
+				  key: value
+				`,
+			},
+			expectedObj: testutil.NewUnstructuredConfigMap("test-cm", "default", map[string]string{"key": "value"}),
+		}),
+
+		Entry("should populate with template and bindings", testCase{
+			globalBindings: map[string]any{"namespace": "test-ns"},
+			methodArgs: []interface{}{
+				&corev1.ConfigMap{},
+				`
+				apiVersion: v1
+				kind: ConfigMap
+				metadata:
+				  name: ($name)
+				  namespace: ($namespace)
+				data:
+				  key: ($value)
+				`,
+				map[string]any{"name": "test-cm", "value": "value"},
+			},
+			expectedObj: testutil.NewConfigMap("test-cm", "test-ns", map[string]string{"key": "value"}),
+		}),
+
+		// Error cases
+		Entry("should fail with no arguments", testCase{
+			expectedFailureLogs: []string{
+				"invalid arguments",
+				"required argument(s) not provided: Template (string)",
+			},
+		}),
+
+		Entry("should fail with no template", testCase{
+			methodArgs: []interface{}{
+				map[string]any{"key": "value"},
+			},
+			expectedFailureLogs: []string{
+				"invalid arguments",
+				"required argument(s) not provided: Template (string)",
+			},
+		}),
+
+		Entry("should fail with multiple template arguments", testCase{
+			methodArgs: []interface{}{
+				"template1",
+				"template2",
+			},
+			expectedFailureLogs: []string{
+				"invalid arguments",
+				"multiple template arguments provided",
+			},
+		}),
+
+		Entry("should fail with multiple object arguments", testCase{
+			methodArgs: []interface{}{
+				&corev1.ConfigMap{},
+				&corev1.Secret{},
+				`
+				apiVersion: v1
+				kind: ConfigMap
+				metadata:
+				  name: test-cm
+				  namespace: default
+				`,
+			},
+			expectedFailureLogs: []string{
+				"invalid arguments",
+				"multiple client.Object arguments provided",
+			},
+		}),
+
+		Entry("should fail with nil object", testCase{
+			methodArgs: []interface{}{
+				(*corev1.ConfigMap)(nil),
+				`
+				apiVersion: v1
+				kind: ConfigMap
+				metadata:
+				  name: test-cm
+				  namespace: default
+				`,
+			},
+			expectedFailureLogs: []string{
+				"invalid arguments",
+				"provided client.Object is nil or has a nil underlying value",
+			},
+		}),
+
+		Entry("should fail with invalid argument type", testCase{
+			methodArgs: []interface{}{
+				123,
+				`
+				apiVersion: v1
+				kind: ConfigMap
+				metadata:
+				  name: test-cm
+				  namespace: default
+				`,
+			},
+			expectedFailureLogs: []string{
+				"invalid arguments",
+				"unexpected argument type: int",
+			},
+		}),
+
+		Entry("should fail with invalid YAML syntax", testCase{
+			methodArgs: []interface{}{
+				`
+				apiVersion: v1
+				kind: ConfigMap
+				metadata:
+				  name: test-cm
+				 badindent: fail
+				`,
+			},
+			expectedFailureLogs: []string{
+				"invalid arguments",
+				"failed to sanitize template content",
+				"yaml: line 4: did not find expected key",
+			},
+		}),
+
+		Entry("should fail with empty template", testCase{
+			methodArgs: []interface{}{
+				"",
+			},
+			expectedFailureLogs: []string{
+				"invalid arguments",
+				"required argument(s) not provided: Template (string)",
+			},
+		}),
+
+		Entry("should fail with missing binding variable", testCase{
+			methodArgs: []interface{}{
+				`
+				apiVersion: v1
+				kind: ConfigMap
+				metadata:
+				  name: ($missing_variable)
+				  namespace: default
+				`,
+				map[string]any{},
+			},
+			expectedFailureLogs: []string{
+				"invalid template/bindings",
+				"variable not defined: $missing_variable",
+			},
+		}),
+
+		Entry("should fail with multiple resources in template", testCase{
+			methodArgs: []interface{}{
+				`
+				apiVersion: v1
+				kind: ConfigMap
+				metadata:
+				  name: test-cm1
+				  namespace: default
+				---
+				apiVersion: v1
+				kind: ConfigMap
+				metadata:
+				  name: test-cm2
+				  namespace: default
+				`,
+			},
+			expectedFailureLogs: []string{
+				"invalid template/bindings",
+				"expected template to contain a single resource; found 2",
+			},
+		}),
+
+		Entry("should fail with type mismatch", testCase{
+			methodArgs: []interface{}{
+				&corev1.Secret{},
+				`
+				apiVersion: v1
+				kind: ConfigMap
+				metadata:
+				  name: test-cm
+				  namespace: default
+				data:
+				  key: value
+				`,
+			},
+			expectedFailureLogs: []string{
+				"failed to save state to object",
+				"destination object type *v1.Secret doesn't match source type *v1.ConfigMap",
+			},
+		}),
+
+		Entry("should fail with unknown GVK in template with typed object", testCase{
+			methodArgs: []interface{}{
+				&corev1.ConfigMap{},
+				`
+				apiVersion: unknown.group/v1
+				kind: UnknownKind
+				metadata:
+				  name: test-unknown
+				  namespace: default
+				`,
+			},
+			expectedFailureLogs: []string{
+				"failed to save state to object",
+				"failed to convert source to typed object",
+				"no kind \"UnknownKind\" is registered for version \"unknown.group/v1\" in scheme",
+			},
+		}),
+	)
+})
+
 // TODO: test RenderMultiple
 // TODO: test RenderToString
 // TODO: test RenderToFile


### PR DESCRIPTION
This completes [render_test.go](https://github.com/guidewire-oss/sawchain/blob/main/render_test.go) with tests for `RenderSingle`, `RenderMultiple`, `RenderToString`, and `RenderToFile`.
Part of https://github.com/guidewire-oss/sawchain/issues/1.