### PR TITLE
feat: improve internal failure messages and info logs

### DIFF
--- a/check_test.go
+++ b/check_test.go
@@ -816,7 +816,7 @@ var _ = Describe("Check and CheckFunc", func() {
 				map[string]any{"key": "value"},
 			},
 			expectedFailureLogs: []string{
-				"[Sawchain] invalid arguments",
+				sawchainPrefix, "invalid arguments",
 				"required argument(s) not provided: Template (string)",
 			},
 		}),
@@ -827,7 +827,7 @@ var _ = Describe("Check and CheckFunc", func() {
 				"",
 			},
 			expectedFailureLogs: []string{
-				"[Sawchain] invalid arguments",
+				sawchainPrefix, "invalid arguments",
 				"template is empty after sanitization",
 			},
 		}),
@@ -844,7 +844,7 @@ var _ = Describe("Check and CheckFunc", func() {
 				`,
 			},
 			expectedFailureLogs: []string{
-				"[Sawchain] invalid arguments",
+				sawchainPrefix, "invalid arguments",
 				"failed to sanitize template content",
 				"ensure leading whitespace is consistent and YAML is indented with spaces (not tabs)",
 				"yaml: line 4: did not find expected key",
@@ -934,7 +934,7 @@ var _ = Describe("Check and CheckFunc", func() {
 				`,
 			},
 			expectedFailureLogs: []string{
-				"[Sawchain] single object insufficient for multi-resource template",
+				sawchainPrefix, "single object insufficient for multi-resource template",
 			},
 		}),
 
@@ -959,7 +959,7 @@ var _ = Describe("Check and CheckFunc", func() {
 				`,
 			},
 			expectedFailureLogs: []string{
-				"[Sawchain] objects slice length must match template resource count",
+				sawchainPrefix, "objects slice length must match template resource count",
 			},
 		}),
 
@@ -987,7 +987,7 @@ var _ = Describe("Check and CheckFunc", func() {
 				`,
 			},
 			expectedFailureLogs: []string{
-				"[Sawchain] failed to save state to object",
+				sawchainPrefix, "failed to save state to object",
 				"destination object type *v1.ConfigMap doesn't match source type *v1.Secret",
 			},
 		}),
@@ -1011,7 +1011,7 @@ var _ = Describe("Check and CheckFunc", func() {
 				`,
 			},
 			expectedFailureLogs: []string{
-				"[Sawchain] objects slice length must match template resource count",
+				sawchainPrefix, "objects slice length must match template resource count",
 			},
 		}),
 	)

--- a/check_test.go
+++ b/check_test.go
@@ -816,7 +816,7 @@ var _ = Describe("Check and CheckFunc", func() {
 				map[string]any{"key": "value"},
 			},
 			expectedFailureLogs: []string{
-				"invalid arguments",
+				"[Sawchain] invalid arguments",
 				"required argument(s) not provided: Template (string)",
 			},
 		}),
@@ -827,7 +827,7 @@ var _ = Describe("Check and CheckFunc", func() {
 				"",
 			},
 			expectedFailureLogs: []string{
-				"invalid arguments",
+				"[Sawchain] invalid arguments",
 				"template is empty after sanitization",
 			},
 		}),
@@ -844,7 +844,7 @@ var _ = Describe("Check and CheckFunc", func() {
 				`,
 			},
 			expectedFailureLogs: []string{
-				"invalid arguments",
+				"[Sawchain] invalid arguments",
 				"failed to sanitize template content",
 				"ensure leading whitespace is consistent and YAML is indented with spaces (not tabs)",
 				"yaml: line 4: did not find expected key",
@@ -934,7 +934,7 @@ var _ = Describe("Check and CheckFunc", func() {
 				`,
 			},
 			expectedFailureLogs: []string{
-				"single object insufficient for multi-resource template",
+				"[Sawchain] single object insufficient for multi-resource template",
 			},
 		}),
 
@@ -959,7 +959,7 @@ var _ = Describe("Check and CheckFunc", func() {
 				`,
 			},
 			expectedFailureLogs: []string{
-				"objects slice length must match template resource count",
+				"[Sawchain] objects slice length must match template resource count",
 			},
 		}),
 
@@ -987,7 +987,7 @@ var _ = Describe("Check and CheckFunc", func() {
 				`,
 			},
 			expectedFailureLogs: []string{
-				"failed to save state to object",
+				"[Sawchain] failed to save state to object",
 				"destination object type *v1.ConfigMap doesn't match source type *v1.Secret",
 			},
 		}),
@@ -1011,7 +1011,7 @@ var _ = Describe("Check and CheckFunc", func() {
 				`,
 			},
 			expectedFailureLogs: []string{
-				"objects slice length must match template resource count",
+				"[Sawchain] objects slice length must match template resource count",
 			},
 		}),
 	)

--- a/create_test.go
+++ b/create_test.go
@@ -530,7 +530,7 @@ var _ = Describe("Create", func() {
 		Entry("should fail with no arguments", testCase{
 			client: &MockClient{Client: testutil.NewStandardFakeClient()},
 			expectedFailureLogs: []string{
-				"[Sawchain] invalid arguments",
+				sawchainPrefix, "invalid arguments",
 				"required argument(s) not provided: Template (string), Object (client.Object), or Objects ([]client.Object)",
 			},
 		}),
@@ -541,7 +541,7 @@ var _ = Describe("Create", func() {
 				[]string{"unexpected", "argument", "type"},
 			},
 			expectedFailureLogs: []string{
-				"[Sawchain] invalid arguments",
+				sawchainPrefix, "invalid arguments",
 				"unexpected argument type: []string",
 			},
 		}),
@@ -552,7 +552,7 @@ var _ = Describe("Create", func() {
 				"non-existent.yaml",
 			},
 			expectedFailureLogs: []string{
-				"[Sawchain] invalid template/bindings",
+				sawchainPrefix, "invalid template/bindings",
 				"if using a file, ensure the file exists and the path is correct",
 			},
 		}),
@@ -563,7 +563,7 @@ var _ = Describe("Create", func() {
 				`invalid: yaml: [`,
 			},
 			expectedFailureLogs: []string{
-				"[Sawchain] invalid arguments",
+				sawchainPrefix, "invalid arguments",
 				"failed to sanitize template content",
 				"ensure leading whitespace is consistent and YAML is indented with spaces (not tabs)",
 				"yaml: mapping values are not allowed in this context",
@@ -582,7 +582,7 @@ var _ = Describe("Create", func() {
 				`,
 			},
 			expectedFailureLogs: []string{
-				"[Sawchain] invalid template/bindings",
+				sawchainPrefix, "invalid template/bindings",
 				"failed to render template",
 				"variable not defined: $missing",
 			},
@@ -613,7 +613,7 @@ var _ = Describe("Create", func() {
 				`,
 			},
 			expectedFailureLogs: []string{
-				"[Sawchain] objects slice length must match template resource count",
+				sawchainPrefix, "objects slice length must match template resource count",
 			},
 		}),
 
@@ -626,7 +626,7 @@ var _ = Describe("Create", func() {
 				},
 			},
 			expectedFailureLogs: []string{
-				"[Sawchain] invalid arguments",
+				sawchainPrefix, "invalid arguments",
 				"client.Object and []client.Object arguments both provided",
 			},
 		}),
@@ -654,7 +654,7 @@ var _ = Describe("Create", func() {
 				testutil.NewConfigMap("test-cm", "default", map[string]string{"key": "value"}),
 			},
 			expectedFailureLogs: []string{
-				"[Sawchain] single object insufficient for multi-resource template",
+				sawchainPrefix, "single object insufficient for multi-resource template",
 			},
 		}),
 
@@ -673,7 +673,7 @@ var _ = Describe("Create", func() {
 				&corev1.Secret{},
 			},
 			expectedFailureLogs: []string{
-				"[Sawchain] failed to save state to object",
+				sawchainPrefix, "failed to save state to object",
 				"destination object type *v1.Secret doesn't match source type *v1.ConfigMap",
 			},
 		}),
@@ -1229,7 +1229,7 @@ var _ = Describe("CreateAndWait", func() {
 		Entry("should fail with no arguments", testCase{
 			client: &MockClient{Client: testutil.NewStandardFakeClient()},
 			expectedFailureLogs: []string{
-				"[Sawchain] invalid arguments",
+				sawchainPrefix, "invalid arguments",
 				"required argument(s) not provided: Template (string), Object (client.Object), or Objects ([]client.Object)",
 			},
 			expectedDuration: fastTimeout,
@@ -1241,7 +1241,7 @@ var _ = Describe("CreateAndWait", func() {
 				[]string{"unexpected", "argument", "type"},
 			},
 			expectedFailureLogs: []string{
-				"[Sawchain] invalid arguments",
+				sawchainPrefix, "invalid arguments",
 				"unexpected argument type: []string",
 			},
 			expectedDuration: fastTimeout,
@@ -1253,7 +1253,7 @@ var _ = Describe("CreateAndWait", func() {
 				"non-existent.yaml",
 			},
 			expectedFailureLogs: []string{
-				"[Sawchain] invalid template/bindings",
+				sawchainPrefix, "invalid template/bindings",
 				"if using a file, ensure the file exists and the path is correct",
 			},
 		}),
@@ -1264,7 +1264,7 @@ var _ = Describe("CreateAndWait", func() {
 				`invalid: yaml: [`,
 			},
 			expectedFailureLogs: []string{
-				"[Sawchain] invalid arguments",
+				sawchainPrefix, "invalid arguments",
 				"failed to sanitize template content",
 				"ensure leading whitespace is consistent and YAML is indented with spaces (not tabs)",
 				"yaml: mapping values are not allowed in this context",
@@ -1284,7 +1284,7 @@ var _ = Describe("CreateAndWait", func() {
 				`,
 			},
 			expectedFailureLogs: []string{
-				"[Sawchain] invalid template/bindings",
+				sawchainPrefix, "invalid template/bindings",
 				"failed to render template",
 				"variable not defined: $missing",
 			},
@@ -1300,7 +1300,7 @@ var _ = Describe("CreateAndWait", func() {
 				testutil.NewConfigMap("test-cm", "default", map[string]string{"key": "value"}),
 			},
 			expectedFailureLogs: []string{
-				"[Sawchain] failed to create with object",
+				sawchainPrefix, "failed to create with object",
 				"simulated create failure",
 			},
 			expectedDuration: fastTimeout,
@@ -1315,7 +1315,7 @@ var _ = Describe("CreateAndWait", func() {
 				testutil.NewConfigMap("test-cm", "default", map[string]string{"key": "value"}),
 			},
 			expectedFailureLogs: []string{
-				"[Sawchain] client cache not synced within timeout",
+				sawchainPrefix, "client cache not synced within timeout",
 				"simulated get failure",
 			},
 			expectedDuration: fastTimeout,
@@ -1333,7 +1333,7 @@ var _ = Describe("CreateAndWait", func() {
 				},
 			},
 			expectedFailureLogs: []string{
-				"[Sawchain] failed to create with object",
+				sawchainPrefix, "failed to create with object",
 				"simulated create failure",
 			},
 			expectedDuration: fastTimeout,
@@ -1351,7 +1351,7 @@ var _ = Describe("CreateAndWait", func() {
 				},
 			},
 			expectedFailureLogs: []string{
-				"[Sawchain] client cache not synced within timeout",
+				sawchainPrefix, "client cache not synced within timeout",
 				"simulated get failure",
 			},
 			expectedDuration: fastTimeout,
@@ -1382,7 +1382,7 @@ var _ = Describe("CreateAndWait", func() {
 				`,
 			},
 			expectedFailureLogs: []string{
-				"[Sawchain] objects slice length must match template resource count",
+				sawchainPrefix, "objects slice length must match template resource count",
 			},
 			expectedDuration: fastTimeout,
 		}),
@@ -1396,7 +1396,7 @@ var _ = Describe("CreateAndWait", func() {
 				},
 			},
 			expectedFailureLogs: []string{
-				"[Sawchain] invalid arguments",
+				sawchainPrefix, "invalid arguments",
 				"client.Object and []client.Object arguments both provided",
 			},
 			expectedDuration: fastTimeout,
@@ -1425,7 +1425,7 @@ var _ = Describe("CreateAndWait", func() {
 				testutil.NewConfigMap("test-cm", "default", map[string]string{"key": "value"}),
 			},
 			expectedFailureLogs: []string{
-				"[Sawchain] single object insufficient for multi-resource template",
+				sawchainPrefix, "single object insufficient for multi-resource template",
 			},
 			expectedDuration: fastTimeout,
 		}),
@@ -1445,7 +1445,7 @@ var _ = Describe("CreateAndWait", func() {
 				&corev1.Secret{},
 			},
 			expectedFailureLogs: []string{
-				"[Sawchain] failed to save state to object",
+				sawchainPrefix, "failed to save state to object",
 				"destination object type *v1.Secret doesn't match source type *v1.ConfigMap",
 			},
 			expectedDuration: fastTimeout,

--- a/create_test.go
+++ b/create_test.go
@@ -530,7 +530,7 @@ var _ = Describe("Create", func() {
 		Entry("should fail with no arguments", testCase{
 			client: &MockClient{Client: testutil.NewStandardFakeClient()},
 			expectedFailureLogs: []string{
-				"invalid arguments",
+				"[Sawchain] invalid arguments",
 				"required argument(s) not provided: Template (string), Object (client.Object), or Objects ([]client.Object)",
 			},
 		}),
@@ -541,7 +541,7 @@ var _ = Describe("Create", func() {
 				[]string{"unexpected", "argument", "type"},
 			},
 			expectedFailureLogs: []string{
-				"invalid arguments",
+				"[Sawchain] invalid arguments",
 				"unexpected argument type: []string",
 			},
 		}),
@@ -552,7 +552,7 @@ var _ = Describe("Create", func() {
 				"non-existent.yaml",
 			},
 			expectedFailureLogs: []string{
-				"invalid template/bindings",
+				"[Sawchain] invalid template/bindings",
 				"if using a file, ensure the file exists and the path is correct",
 			},
 		}),
@@ -563,7 +563,7 @@ var _ = Describe("Create", func() {
 				`invalid: yaml: [`,
 			},
 			expectedFailureLogs: []string{
-				"invalid arguments",
+				"[Sawchain] invalid arguments",
 				"failed to sanitize template content",
 				"ensure leading whitespace is consistent and YAML is indented with spaces (not tabs)",
 				"yaml: mapping values are not allowed in this context",
@@ -582,7 +582,7 @@ var _ = Describe("Create", func() {
 				`,
 			},
 			expectedFailureLogs: []string{
-				"invalid template/bindings",
+				"[Sawchain] invalid template/bindings",
 				"failed to render template",
 				"variable not defined: $missing",
 			},
@@ -613,7 +613,7 @@ var _ = Describe("Create", func() {
 				`,
 			},
 			expectedFailureLogs: []string{
-				"objects slice length must match template resource count",
+				"[Sawchain] objects slice length must match template resource count",
 			},
 		}),
 
@@ -626,7 +626,7 @@ var _ = Describe("Create", func() {
 				},
 			},
 			expectedFailureLogs: []string{
-				"invalid arguments",
+				"[Sawchain] invalid arguments",
 				"client.Object and []client.Object arguments both provided",
 			},
 		}),
@@ -654,7 +654,7 @@ var _ = Describe("Create", func() {
 				testutil.NewConfigMap("test-cm", "default", map[string]string{"key": "value"}),
 			},
 			expectedFailureLogs: []string{
-				"single object insufficient for multi-resource template",
+				"[Sawchain] single object insufficient for multi-resource template",
 			},
 		}),
 
@@ -673,7 +673,7 @@ var _ = Describe("Create", func() {
 				&corev1.Secret{},
 			},
 			expectedFailureLogs: []string{
-				"failed to save state to object",
+				"[Sawchain] failed to save state to object",
 				"destination object type *v1.Secret doesn't match source type *v1.ConfigMap",
 			},
 		}),
@@ -1229,7 +1229,7 @@ var _ = Describe("CreateAndWait", func() {
 		Entry("should fail with no arguments", testCase{
 			client: &MockClient{Client: testutil.NewStandardFakeClient()},
 			expectedFailureLogs: []string{
-				"invalid arguments",
+				"[Sawchain] invalid arguments",
 				"required argument(s) not provided: Template (string), Object (client.Object), or Objects ([]client.Object)",
 			},
 			expectedDuration: fastTimeout,
@@ -1241,7 +1241,7 @@ var _ = Describe("CreateAndWait", func() {
 				[]string{"unexpected", "argument", "type"},
 			},
 			expectedFailureLogs: []string{
-				"invalid arguments",
+				"[Sawchain] invalid arguments",
 				"unexpected argument type: []string",
 			},
 			expectedDuration: fastTimeout,
@@ -1253,7 +1253,7 @@ var _ = Describe("CreateAndWait", func() {
 				"non-existent.yaml",
 			},
 			expectedFailureLogs: []string{
-				"invalid template/bindings",
+				"[Sawchain] invalid template/bindings",
 				"if using a file, ensure the file exists and the path is correct",
 			},
 		}),
@@ -1264,7 +1264,7 @@ var _ = Describe("CreateAndWait", func() {
 				`invalid: yaml: [`,
 			},
 			expectedFailureLogs: []string{
-				"invalid arguments",
+				"[Sawchain] invalid arguments",
 				"failed to sanitize template content",
 				"ensure leading whitespace is consistent and YAML is indented with spaces (not tabs)",
 				"yaml: mapping values are not allowed in this context",
@@ -1284,7 +1284,7 @@ var _ = Describe("CreateAndWait", func() {
 				`,
 			},
 			expectedFailureLogs: []string{
-				"invalid template/bindings",
+				"[Sawchain] invalid template/bindings",
 				"failed to render template",
 				"variable not defined: $missing",
 			},
@@ -1300,7 +1300,8 @@ var _ = Describe("CreateAndWait", func() {
 				testutil.NewConfigMap("test-cm", "default", map[string]string{"key": "value"}),
 			},
 			expectedFailureLogs: []string{
-				"failed to create with object",
+				"[Sawchain] failed to create with object",
+				"simulated create failure",
 			},
 			expectedDuration: fastTimeout,
 		}),
@@ -1314,7 +1315,8 @@ var _ = Describe("CreateAndWait", func() {
 				testutil.NewConfigMap("test-cm", "default", map[string]string{"key": "value"}),
 			},
 			expectedFailureLogs: []string{
-				"client cache not synced within timeout",
+				"[Sawchain] client cache not synced within timeout",
+				"simulated get failure",
 			},
 			expectedDuration: fastTimeout,
 		}),
@@ -1331,7 +1333,8 @@ var _ = Describe("CreateAndWait", func() {
 				},
 			},
 			expectedFailureLogs: []string{
-				"failed to create with object",
+				"[Sawchain] failed to create with object",
+				"simulated create failure",
 			},
 			expectedDuration: fastTimeout,
 		}),
@@ -1348,7 +1351,8 @@ var _ = Describe("CreateAndWait", func() {
 				},
 			},
 			expectedFailureLogs: []string{
-				"client cache not synced within timeout",
+				"[Sawchain] client cache not synced within timeout",
+				"simulated get failure",
 			},
 			expectedDuration: fastTimeout,
 		}),
@@ -1378,7 +1382,7 @@ var _ = Describe("CreateAndWait", func() {
 				`,
 			},
 			expectedFailureLogs: []string{
-				"objects slice length must match template resource count",
+				"[Sawchain] objects slice length must match template resource count",
 			},
 			expectedDuration: fastTimeout,
 		}),
@@ -1392,7 +1396,7 @@ var _ = Describe("CreateAndWait", func() {
 				},
 			},
 			expectedFailureLogs: []string{
-				"invalid arguments",
+				"[Sawchain] invalid arguments",
 				"client.Object and []client.Object arguments both provided",
 			},
 			expectedDuration: fastTimeout,
@@ -1421,7 +1425,7 @@ var _ = Describe("CreateAndWait", func() {
 				testutil.NewConfigMap("test-cm", "default", map[string]string{"key": "value"}),
 			},
 			expectedFailureLogs: []string{
-				"single object insufficient for multi-resource template",
+				"[Sawchain] single object insufficient for multi-resource template",
 			},
 			expectedDuration: fastTimeout,
 		}),
@@ -1441,7 +1445,7 @@ var _ = Describe("CreateAndWait", func() {
 				&corev1.Secret{},
 			},
 			expectedFailureLogs: []string{
-				"failed to save state to object",
+				"[Sawchain] failed to save state to object",
 				"destination object type *v1.Secret doesn't match source type *v1.ConfigMap",
 			},
 			expectedDuration: fastTimeout,

--- a/delete_test.go
+++ b/delete_test.go
@@ -386,7 +386,7 @@ var _ = Describe("Delete", func() {
 		Entry("should fail with no arguments", testCase{
 			client: &MockClient{Client: testutil.NewStandardFakeClient()},
 			expectedFailureLogs: []string{
-				"[Sawchain] invalid arguments",
+				sawchainPrefix, "invalid arguments",
 				"required argument(s) not provided: Template (string), Object (client.Object), or Objects ([]client.Object)",
 			},
 		}),
@@ -397,7 +397,7 @@ var _ = Describe("Delete", func() {
 				[]string{"unexpected", "argument", "type"},
 			},
 			expectedFailureLogs: []string{
-				"[Sawchain] invalid arguments",
+				sawchainPrefix, "invalid arguments",
 				"unexpected argument type: []string",
 			},
 		}),
@@ -408,7 +408,7 @@ var _ = Describe("Delete", func() {
 				"non-existent.yaml",
 			},
 			expectedFailureLogs: []string{
-				"[Sawchain] invalid template/bindings",
+				sawchainPrefix, "invalid template/bindings",
 				"if using a file, ensure the file exists and the path is correct",
 			},
 		}),
@@ -419,7 +419,7 @@ var _ = Describe("Delete", func() {
 				`invalid: yaml: [`,
 			},
 			expectedFailureLogs: []string{
-				"[Sawchain] invalid arguments",
+				sawchainPrefix, "invalid arguments",
 				"failed to sanitize template content",
 				"ensure leading whitespace is consistent and YAML is indented with spaces (not tabs)",
 				"yaml: mapping values are not allowed in this context",
@@ -438,7 +438,7 @@ var _ = Describe("Delete", func() {
 				`,
 			},
 			expectedFailureLogs: []string{
-				"[Sawchain] invalid template/bindings",
+				sawchainPrefix, "invalid template/bindings",
 				"failed to render template",
 				"variable not defined: $missing",
 			},
@@ -453,7 +453,7 @@ var _ = Describe("Delete", func() {
 				},
 			},
 			expectedFailureLogs: []string{
-				"[Sawchain] invalid arguments",
+				sawchainPrefix, "invalid arguments",
 				"client.Object and []client.Object arguments both provided",
 			},
 		}),
@@ -862,7 +862,7 @@ var _ = Describe("DeleteAndWait", func() {
 		Entry("should fail with no arguments", testCase{
 			client: &MockClient{Client: testutil.NewStandardFakeClient()},
 			expectedFailureLogs: []string{
-				"[Sawchain] invalid arguments",
+				sawchainPrefix, "invalid arguments",
 				"required argument(s) not provided: Template (string), Object (client.Object), or Objects ([]client.Object)",
 			},
 			expectedDuration: fastTimeout,
@@ -874,7 +874,7 @@ var _ = Describe("DeleteAndWait", func() {
 				[]string{"unexpected", "argument", "type"},
 			},
 			expectedFailureLogs: []string{
-				"[Sawchain] invalid arguments",
+				sawchainPrefix, "invalid arguments",
 				"unexpected argument type: []string",
 			},
 			expectedDuration: fastTimeout,
@@ -886,7 +886,7 @@ var _ = Describe("DeleteAndWait", func() {
 				"non-existent.yaml",
 			},
 			expectedFailureLogs: []string{
-				"[Sawchain] invalid template/bindings",
+				sawchainPrefix, "invalid template/bindings",
 				"if using a file, ensure the file exists and the path is correct",
 			},
 		}),
@@ -897,7 +897,7 @@ var _ = Describe("DeleteAndWait", func() {
 				`invalid: yaml: [`,
 			},
 			expectedFailureLogs: []string{
-				"[Sawchain] invalid arguments",
+				sawchainPrefix, "invalid arguments",
 				"failed to sanitize template content",
 				"ensure leading whitespace is consistent and YAML is indented with spaces (not tabs)",
 				"yaml: mapping values are not allowed in this context",
@@ -917,7 +917,7 @@ var _ = Describe("DeleteAndWait", func() {
 				`,
 			},
 			expectedFailureLogs: []string{
-				"[Sawchain] invalid template/bindings",
+				sawchainPrefix, "invalid template/bindings",
 				"failed to render template",
 				"variable not defined: $missing",
 			},
@@ -936,7 +936,7 @@ var _ = Describe("DeleteAndWait", func() {
 				testutil.NewConfigMap("test-cm", "default", nil),
 			},
 			expectedFailureLogs: []string{
-				"[Sawchain] failed to delete with object",
+				sawchainPrefix, "failed to delete with object",
 				"simulated delete failure",
 			},
 			expectedDuration: fastTimeout,
@@ -954,7 +954,7 @@ var _ = Describe("DeleteAndWait", func() {
 				testutil.NewConfigMap("test-cm", "default", nil),
 			},
 			expectedFailureLogs: []string{
-				"[Sawchain] client cache not synced within timeout",
+				sawchainPrefix, "client cache not synced within timeout",
 				"simulated get failure",
 			},
 			expectedDuration: fastTimeout,
@@ -976,7 +976,7 @@ var _ = Describe("DeleteAndWait", func() {
 				},
 			},
 			expectedFailureLogs: []string{
-				"[Sawchain] failed to delete with object",
+				sawchainPrefix, "failed to delete with object",
 				"simulated delete failure",
 			},
 			expectedDuration: fastTimeout,
@@ -998,7 +998,7 @@ var _ = Describe("DeleteAndWait", func() {
 				},
 			},
 			expectedFailureLogs: []string{
-				"[Sawchain] client cache not synced within timeout",
+				sawchainPrefix, "client cache not synced within timeout",
 				"simulated get failure",
 			},
 			expectedDuration: fastTimeout,

--- a/delete_test.go
+++ b/delete_test.go
@@ -386,7 +386,7 @@ var _ = Describe("Delete", func() {
 		Entry("should fail with no arguments", testCase{
 			client: &MockClient{Client: testutil.NewStandardFakeClient()},
 			expectedFailureLogs: []string{
-				"invalid arguments",
+				"[Sawchain] invalid arguments",
 				"required argument(s) not provided: Template (string), Object (client.Object), or Objects ([]client.Object)",
 			},
 		}),
@@ -397,7 +397,7 @@ var _ = Describe("Delete", func() {
 				[]string{"unexpected", "argument", "type"},
 			},
 			expectedFailureLogs: []string{
-				"invalid arguments",
+				"[Sawchain] invalid arguments",
 				"unexpected argument type: []string",
 			},
 		}),
@@ -408,7 +408,7 @@ var _ = Describe("Delete", func() {
 				"non-existent.yaml",
 			},
 			expectedFailureLogs: []string{
-				"invalid template/bindings",
+				"[Sawchain] invalid template/bindings",
 				"if using a file, ensure the file exists and the path is correct",
 			},
 		}),
@@ -419,7 +419,7 @@ var _ = Describe("Delete", func() {
 				`invalid: yaml: [`,
 			},
 			expectedFailureLogs: []string{
-				"invalid arguments",
+				"[Sawchain] invalid arguments",
 				"failed to sanitize template content",
 				"ensure leading whitespace is consistent and YAML is indented with spaces (not tabs)",
 				"yaml: mapping values are not allowed in this context",
@@ -438,7 +438,7 @@ var _ = Describe("Delete", func() {
 				`,
 			},
 			expectedFailureLogs: []string{
-				"invalid template/bindings",
+				"[Sawchain] invalid template/bindings",
 				"failed to render template",
 				"variable not defined: $missing",
 			},
@@ -453,7 +453,7 @@ var _ = Describe("Delete", func() {
 				},
 			},
 			expectedFailureLogs: []string{
-				"invalid arguments",
+				"[Sawchain] invalid arguments",
 				"client.Object and []client.Object arguments both provided",
 			},
 		}),
@@ -862,7 +862,7 @@ var _ = Describe("DeleteAndWait", func() {
 		Entry("should fail with no arguments", testCase{
 			client: &MockClient{Client: testutil.NewStandardFakeClient()},
 			expectedFailureLogs: []string{
-				"invalid arguments",
+				"[Sawchain] invalid arguments",
 				"required argument(s) not provided: Template (string), Object (client.Object), or Objects ([]client.Object)",
 			},
 			expectedDuration: fastTimeout,
@@ -874,7 +874,7 @@ var _ = Describe("DeleteAndWait", func() {
 				[]string{"unexpected", "argument", "type"},
 			},
 			expectedFailureLogs: []string{
-				"invalid arguments",
+				"[Sawchain] invalid arguments",
 				"unexpected argument type: []string",
 			},
 			expectedDuration: fastTimeout,
@@ -886,7 +886,7 @@ var _ = Describe("DeleteAndWait", func() {
 				"non-existent.yaml",
 			},
 			expectedFailureLogs: []string{
-				"invalid template/bindings",
+				"[Sawchain] invalid template/bindings",
 				"if using a file, ensure the file exists and the path is correct",
 			},
 		}),
@@ -897,7 +897,7 @@ var _ = Describe("DeleteAndWait", func() {
 				`invalid: yaml: [`,
 			},
 			expectedFailureLogs: []string{
-				"invalid arguments",
+				"[Sawchain] invalid arguments",
 				"failed to sanitize template content",
 				"ensure leading whitespace is consistent and YAML is indented with spaces (not tabs)",
 				"yaml: mapping values are not allowed in this context",
@@ -917,7 +917,7 @@ var _ = Describe("DeleteAndWait", func() {
 				`,
 			},
 			expectedFailureLogs: []string{
-				"invalid template/bindings",
+				"[Sawchain] invalid template/bindings",
 				"failed to render template",
 				"variable not defined: $missing",
 			},
@@ -936,7 +936,8 @@ var _ = Describe("DeleteAndWait", func() {
 				testutil.NewConfigMap("test-cm", "default", nil),
 			},
 			expectedFailureLogs: []string{
-				"failed to delete with object",
+				"[Sawchain] failed to delete with object",
+				"simulated delete failure",
 			},
 			expectedDuration: fastTimeout,
 		}),
@@ -953,7 +954,8 @@ var _ = Describe("DeleteAndWait", func() {
 				testutil.NewConfigMap("test-cm", "default", nil),
 			},
 			expectedFailureLogs: []string{
-				"client cache not synced",
+				"[Sawchain] client cache not synced within timeout",
+				"simulated get failure",
 			},
 			expectedDuration: fastTimeout,
 		}),
@@ -974,7 +976,8 @@ var _ = Describe("DeleteAndWait", func() {
 				},
 			},
 			expectedFailureLogs: []string{
-				"failed to delete with object",
+				"[Sawchain] failed to delete with object",
+				"simulated delete failure",
 			},
 			expectedDuration: fastTimeout,
 		}),
@@ -995,7 +998,8 @@ var _ = Describe("DeleteAndWait", func() {
 				},
 			},
 			expectedFailureLogs: []string{
-				"client cache not synced",
+				"[Sawchain] client cache not synced within timeout",
+				"simulated get failure",
 			},
 			expectedDuration: fastTimeout,
 		}),

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -32,7 +32,7 @@ import "github.com/guidewire-oss/sawchain"
   - [func \(s \*Sawchain\) UpdateAndWait\(ctx context.Context, args ...interface\{\}\)](<#Sawchain.UpdateAndWait>)
 
 <a name="Sawchain"></a>
-## type [Sawchain](<https://github.com/guidewire-oss/sawchain/blob/main/sawchain.go#L50-L55>)
+## type [Sawchain](<https://github.com/guidewire-oss/sawchain/blob/main/sawchain.go#L51-L56>)
 
 Sawchain provides utilities for K8s YAML\-driven testing—powered by Chainsaw. It includes helpers to reliably create/update/delete test resources, Gomega\-friendly APIs to simplify assertions, and more.
 
@@ -47,7 +47,7 @@ type Sawchain struct {
 ```
 
 <a name="New"></a>
-### func [New](<https://github.com/guidewire-oss/sawchain/blob/main/sawchain.go#L89>)
+### func [New](<https://github.com/guidewire-oss/sawchain/blob/main/sawchain.go#L90>)
 
 ```go
 func New(t testing.TB, c client.Client, args ...interface{}) *Sawchain

--- a/matchers_test.go
+++ b/matchers_test.go
@@ -276,7 +276,7 @@ var _ = Describe("MatchYAML", func() {
 			}),
 			template: `invalid: yaml: content`,
 			expectedFailureLogs: []string{
-				"invalid arguments",
+				"[Sawchain] invalid arguments",
 				"failed to sanitize template content",
 				"ensure leading whitespace is consistent and YAML is indented with spaces (not tabs)",
 				"yaml: mapping values are not allowed in this context",
@@ -309,7 +309,7 @@ var _ = Describe("MatchYAML", func() {
 				---
 			`,
 			expectedFailureLogs: []string{
-				"invalid arguments",
+				"[Sawchain] invalid arguments",
 				"template is empty after sanitization",
 			},
 		}),

--- a/matchers_test.go
+++ b/matchers_test.go
@@ -276,7 +276,7 @@ var _ = Describe("MatchYAML", func() {
 			}),
 			template: `invalid: yaml: content`,
 			expectedFailureLogs: []string{
-				"[Sawchain] invalid arguments",
+				sawchainPrefix, "invalid arguments",
 				"failed to sanitize template content",
 				"ensure leading whitespace is consistent and YAML is indented with spaces (not tabs)",
 				"yaml: mapping values are not allowed in this context",
@@ -309,7 +309,7 @@ var _ = Describe("MatchYAML", func() {
 				---
 			`,
 			expectedFailureLogs: []string{
-				"[Sawchain] invalid arguments",
+				sawchainPrefix, "invalid arguments",
 				"template is empty after sanitization",
 			},
 		}),

--- a/render_test.go
+++ b/render_test.go
@@ -181,7 +181,7 @@ var _ = Describe("RenderSingle", func() {
 		// Error cases
 		Entry("should fail with no arguments", testCase{
 			expectedFailureLogs: []string{
-				"invalid arguments",
+				"[Sawchain] invalid arguments",
 				"required argument(s) not provided: Template (string)",
 			},
 		}),
@@ -191,7 +191,7 @@ var _ = Describe("RenderSingle", func() {
 				map[string]any{"key": "value"},
 			},
 			expectedFailureLogs: []string{
-				"invalid arguments",
+				"[Sawchain] invalid arguments",
 				"required argument(s) not provided: Template (string)",
 			},
 		}),
@@ -202,7 +202,7 @@ var _ = Describe("RenderSingle", func() {
 				"template2",
 			},
 			expectedFailureLogs: []string{
-				"invalid arguments",
+				"[Sawchain] invalid arguments",
 				"multiple template arguments provided",
 			},
 		}),
@@ -220,7 +220,7 @@ var _ = Describe("RenderSingle", func() {
 				`,
 			},
 			expectedFailureLogs: []string{
-				"invalid arguments",
+				"[Sawchain] invalid arguments",
 				"multiple client.Object arguments provided",
 			},
 		}),
@@ -237,7 +237,7 @@ var _ = Describe("RenderSingle", func() {
 				`,
 			},
 			expectedFailureLogs: []string{
-				"invalid arguments",
+				"[Sawchain] invalid arguments",
 				"provided client.Object is nil or has a nil underlying value",
 			},
 		}),
@@ -254,7 +254,7 @@ var _ = Describe("RenderSingle", func() {
 				`,
 			},
 			expectedFailureLogs: []string{
-				"invalid arguments",
+				"[Sawchain] invalid arguments",
 				"unexpected argument type: int",
 			},
 		}),
@@ -264,7 +264,7 @@ var _ = Describe("RenderSingle", func() {
 				"non-existent.yaml",
 			},
 			expectedFailureLogs: []string{
-				"invalid template/bindings",
+				"[Sawchain] invalid template/bindings",
 				"if using a file, ensure the file exists and the path is correct",
 			},
 		}),
@@ -280,7 +280,7 @@ var _ = Describe("RenderSingle", func() {
 				`,
 			},
 			expectedFailureLogs: []string{
-				"invalid arguments",
+				"[Sawchain] invalid arguments",
 				"failed to sanitize template content",
 				"ensure leading whitespace is consistent and YAML is indented with spaces (not tabs)",
 				"yaml: line 4: did not find expected key",
@@ -292,7 +292,7 @@ var _ = Describe("RenderSingle", func() {
 				"",
 			},
 			expectedFailureLogs: []string{
-				"invalid arguments",
+				"[Sawchain] invalid arguments",
 				"template is empty after sanitization",
 			},
 		}),
@@ -309,7 +309,7 @@ var _ = Describe("RenderSingle", func() {
 				map[string]any{},
 			},
 			expectedFailureLogs: []string{
-				"invalid template/bindings",
+				"[Sawchain] invalid template/bindings",
 				"failed to render template",
 				"variable not defined: $missing_binding",
 			},
@@ -332,7 +332,7 @@ var _ = Describe("RenderSingle", func() {
 				`,
 			},
 			expectedFailureLogs: []string{
-				"invalid template/bindings",
+				"[Sawchain] invalid template/bindings",
 				"expected template to contain a single resource; found 2",
 			},
 		}),
@@ -351,7 +351,7 @@ var _ = Describe("RenderSingle", func() {
 				`,
 			},
 			expectedFailureLogs: []string{
-				"failed to save state to object",
+				"[Sawchain] failed to save state to object",
 				"destination object type *v1.Secret doesn't match source type *v1.ConfigMap",
 			},
 		}),
@@ -368,7 +368,7 @@ var _ = Describe("RenderSingle", func() {
 				`,
 			},
 			expectedFailureLogs: []string{
-				"failed to save state to object",
+				"[Sawchain] failed to save state to object",
 				"failed to convert source to typed object",
 				"no kind \"UnknownKind\" is registered for version \"unknown.group/v1\" in scheme",
 			},
@@ -648,7 +648,7 @@ var _ = Describe("RenderMultiple", func() {
 		// Error cases
 		Entry("should fail with no arguments", testCase{
 			expectedFailureLogs: []string{
-				"invalid arguments",
+				"[Sawchain] invalid arguments",
 				"required argument(s) not provided: Template (string)",
 			},
 		}),
@@ -658,7 +658,7 @@ var _ = Describe("RenderMultiple", func() {
 				map[string]any{"key": "value"},
 			},
 			expectedFailureLogs: []string{
-				"invalid arguments",
+				"[Sawchain] invalid arguments",
 				"required argument(s) not provided: Template (string)",
 			},
 		}),
@@ -669,7 +669,7 @@ var _ = Describe("RenderMultiple", func() {
 				"template2",
 			},
 			expectedFailureLogs: []string{
-				"invalid arguments",
+				"[Sawchain] invalid arguments",
 				"multiple template arguments provided",
 			},
 		}),
@@ -687,7 +687,7 @@ var _ = Describe("RenderMultiple", func() {
 				`,
 			},
 			expectedFailureLogs: []string{
-				"invalid arguments",
+				"[Sawchain] invalid arguments",
 				"multiple []client.Object arguments provided",
 			},
 		}),
@@ -704,7 +704,7 @@ var _ = Describe("RenderMultiple", func() {
 				`,
 			},
 			expectedFailureLogs: []string{
-				"invalid arguments",
+				"[Sawchain] invalid arguments",
 				"unexpected argument type: int",
 			},
 		}),
@@ -714,7 +714,7 @@ var _ = Describe("RenderMultiple", func() {
 				"non-existent.yaml",
 			},
 			expectedFailureLogs: []string{
-				"invalid template/bindings",
+				"[Sawchain] invalid template/bindings",
 				"if using a file, ensure the file exists and the path is correct",
 			},
 		}),
@@ -730,7 +730,7 @@ var _ = Describe("RenderMultiple", func() {
 				`,
 			},
 			expectedFailureLogs: []string{
-				"invalid arguments",
+				"[Sawchain] invalid arguments",
 				"failed to sanitize template content",
 				"ensure leading whitespace is consistent and YAML is indented with spaces (not tabs)",
 				"yaml: line 4: did not find expected key",
@@ -742,7 +742,7 @@ var _ = Describe("RenderMultiple", func() {
 				"",
 			},
 			expectedFailureLogs: []string{
-				"invalid arguments",
+				"[Sawchain] invalid arguments",
 				"template is empty after sanitization",
 			},
 		}),
@@ -765,7 +765,7 @@ var _ = Describe("RenderMultiple", func() {
 				map[string]any{},
 			},
 			expectedFailureLogs: []string{
-				"invalid template/bindings",
+				"[Sawchain] invalid template/bindings",
 				"failed to render template",
 				"variable not defined: $missing_binding",
 			},
@@ -795,7 +795,7 @@ var _ = Describe("RenderMultiple", func() {
 				`,
 			},
 			expectedFailureLogs: []string{
-				"objects slice length must match template resource count",
+				"[Sawchain] objects slice length must match template resource count",
 			},
 		}),
 
@@ -825,7 +825,7 @@ var _ = Describe("RenderMultiple", func() {
 				`,
 			},
 			expectedFailureLogs: []string{
-				"objects slice length must match template resource count",
+				"[Sawchain] objects slice length must match template resource count",
 			},
 		}),
 
@@ -854,7 +854,7 @@ var _ = Describe("RenderMultiple", func() {
 				`,
 			},
 			expectedFailureLogs: []string{
-				"failed to save state to object",
+				"[Sawchain] failed to save state to object",
 				"destination object type *v1.Secret doesn't match source type",
 			},
 		}),
@@ -873,7 +873,7 @@ var _ = Describe("RenderMultiple", func() {
 				`,
 			},
 			expectedFailureLogs: []string{
-				"failed to save state to object",
+				"[Sawchain] failed to save state to object",
 				"failed to convert source to typed object",
 				"no kind \"UnknownKind\" is registered for version \"unknown.group/v1\" in scheme",
 			},
@@ -1282,7 +1282,7 @@ status:
 		Entry("should fail with non-existent template file", testCase{
 			template: "non-existent.yaml",
 			expectedFailureLogs: []string{
-				"invalid template/bindings",
+				"[Sawchain] invalid template/bindings",
 				"if using a file, ensure the file exists and the path is correct",
 			},
 		}),
@@ -1296,7 +1296,7 @@ status:
 				 badindent: fail
 				`,
 			expectedFailureLogs: []string{
-				"invalid arguments",
+				"[Sawchain] invalid arguments",
 				"failed to sanitize template content",
 				"ensure leading whitespace is consistent and YAML is indented with spaces (not tabs)",
 				"yaml: line 4: did not find expected key",
@@ -1306,7 +1306,7 @@ status:
 		Entry("should fail with empty template", testCase{
 			template: "",
 			expectedFailureLogs: []string{
-				"invalid arguments",
+				"[Sawchain] invalid arguments",
 				"template is empty after sanitization",
 			},
 		}),
@@ -1320,7 +1320,7 @@ status:
 				  namespace: default
 				`,
 			expectedFailureLogs: []string{
-				"invalid template/bindings",
+				"[Sawchain] invalid template/bindings",
 				"failed to render template",
 				"variable not defined: $missing_binding",
 			},
@@ -1341,7 +1341,7 @@ status:
 				  namespace: default
 				`,
 			expectedFailureLogs: []string{
-				"invalid template/bindings",
+				"[Sawchain] invalid template/bindings",
 				"failed to render template",
 				"variable not defined: $missing_binding",
 			},

--- a/render_test.go
+++ b/render_test.go
@@ -181,7 +181,7 @@ var _ = Describe("RenderSingle", func() {
 		// Error cases
 		Entry("should fail with no arguments", testCase{
 			expectedFailureLogs: []string{
-				"[Sawchain] invalid arguments",
+				sawchainPrefix, "invalid arguments",
 				"required argument(s) not provided: Template (string)",
 			},
 		}),
@@ -191,7 +191,7 @@ var _ = Describe("RenderSingle", func() {
 				map[string]any{"key": "value"},
 			},
 			expectedFailureLogs: []string{
-				"[Sawchain] invalid arguments",
+				sawchainPrefix, "invalid arguments",
 				"required argument(s) not provided: Template (string)",
 			},
 		}),
@@ -202,7 +202,7 @@ var _ = Describe("RenderSingle", func() {
 				"template2",
 			},
 			expectedFailureLogs: []string{
-				"[Sawchain] invalid arguments",
+				sawchainPrefix, "invalid arguments",
 				"multiple template arguments provided",
 			},
 		}),
@@ -220,7 +220,7 @@ var _ = Describe("RenderSingle", func() {
 				`,
 			},
 			expectedFailureLogs: []string{
-				"[Sawchain] invalid arguments",
+				sawchainPrefix, "invalid arguments",
 				"multiple client.Object arguments provided",
 			},
 		}),
@@ -237,7 +237,7 @@ var _ = Describe("RenderSingle", func() {
 				`,
 			},
 			expectedFailureLogs: []string{
-				"[Sawchain] invalid arguments",
+				sawchainPrefix, "invalid arguments",
 				"provided client.Object is nil or has a nil underlying value",
 			},
 		}),
@@ -254,7 +254,7 @@ var _ = Describe("RenderSingle", func() {
 				`,
 			},
 			expectedFailureLogs: []string{
-				"[Sawchain] invalid arguments",
+				sawchainPrefix, "invalid arguments",
 				"unexpected argument type: int",
 			},
 		}),
@@ -264,7 +264,7 @@ var _ = Describe("RenderSingle", func() {
 				"non-existent.yaml",
 			},
 			expectedFailureLogs: []string{
-				"[Sawchain] invalid template/bindings",
+				sawchainPrefix, "invalid template/bindings",
 				"if using a file, ensure the file exists and the path is correct",
 			},
 		}),
@@ -280,7 +280,7 @@ var _ = Describe("RenderSingle", func() {
 				`,
 			},
 			expectedFailureLogs: []string{
-				"[Sawchain] invalid arguments",
+				sawchainPrefix, "invalid arguments",
 				"failed to sanitize template content",
 				"ensure leading whitespace is consistent and YAML is indented with spaces (not tabs)",
 				"yaml: line 4: did not find expected key",
@@ -292,7 +292,7 @@ var _ = Describe("RenderSingle", func() {
 				"",
 			},
 			expectedFailureLogs: []string{
-				"[Sawchain] invalid arguments",
+				sawchainPrefix, "invalid arguments",
 				"template is empty after sanitization",
 			},
 		}),
@@ -309,7 +309,7 @@ var _ = Describe("RenderSingle", func() {
 				map[string]any{},
 			},
 			expectedFailureLogs: []string{
-				"[Sawchain] invalid template/bindings",
+				sawchainPrefix, "invalid template/bindings",
 				"failed to render template",
 				"variable not defined: $missing_binding",
 			},
@@ -332,7 +332,7 @@ var _ = Describe("RenderSingle", func() {
 				`,
 			},
 			expectedFailureLogs: []string{
-				"[Sawchain] invalid template/bindings",
+				sawchainPrefix, "invalid template/bindings",
 				"expected template to contain a single resource; found 2",
 			},
 		}),
@@ -351,7 +351,7 @@ var _ = Describe("RenderSingle", func() {
 				`,
 			},
 			expectedFailureLogs: []string{
-				"[Sawchain] failed to save state to object",
+				sawchainPrefix, "failed to save state to object",
 				"destination object type *v1.Secret doesn't match source type *v1.ConfigMap",
 			},
 		}),
@@ -368,7 +368,7 @@ var _ = Describe("RenderSingle", func() {
 				`,
 			},
 			expectedFailureLogs: []string{
-				"[Sawchain] failed to save state to object",
+				sawchainPrefix, "failed to save state to object",
 				"failed to convert source to typed object",
 				"no kind \"UnknownKind\" is registered for version \"unknown.group/v1\" in scheme",
 			},
@@ -648,7 +648,7 @@ var _ = Describe("RenderMultiple", func() {
 		// Error cases
 		Entry("should fail with no arguments", testCase{
 			expectedFailureLogs: []string{
-				"[Sawchain] invalid arguments",
+				sawchainPrefix, "invalid arguments",
 				"required argument(s) not provided: Template (string)",
 			},
 		}),
@@ -658,7 +658,7 @@ var _ = Describe("RenderMultiple", func() {
 				map[string]any{"key": "value"},
 			},
 			expectedFailureLogs: []string{
-				"[Sawchain] invalid arguments",
+				sawchainPrefix, "invalid arguments",
 				"required argument(s) not provided: Template (string)",
 			},
 		}),
@@ -669,7 +669,7 @@ var _ = Describe("RenderMultiple", func() {
 				"template2",
 			},
 			expectedFailureLogs: []string{
-				"[Sawchain] invalid arguments",
+				sawchainPrefix, "invalid arguments",
 				"multiple template arguments provided",
 			},
 		}),
@@ -687,7 +687,7 @@ var _ = Describe("RenderMultiple", func() {
 				`,
 			},
 			expectedFailureLogs: []string{
-				"[Sawchain] invalid arguments",
+				sawchainPrefix, "invalid arguments",
 				"multiple []client.Object arguments provided",
 			},
 		}),
@@ -704,7 +704,7 @@ var _ = Describe("RenderMultiple", func() {
 				`,
 			},
 			expectedFailureLogs: []string{
-				"[Sawchain] invalid arguments",
+				sawchainPrefix, "invalid arguments",
 				"unexpected argument type: int",
 			},
 		}),
@@ -714,7 +714,7 @@ var _ = Describe("RenderMultiple", func() {
 				"non-existent.yaml",
 			},
 			expectedFailureLogs: []string{
-				"[Sawchain] invalid template/bindings",
+				sawchainPrefix, "invalid template/bindings",
 				"if using a file, ensure the file exists and the path is correct",
 			},
 		}),
@@ -730,7 +730,7 @@ var _ = Describe("RenderMultiple", func() {
 				`,
 			},
 			expectedFailureLogs: []string{
-				"[Sawchain] invalid arguments",
+				sawchainPrefix, "invalid arguments",
 				"failed to sanitize template content",
 				"ensure leading whitespace is consistent and YAML is indented with spaces (not tabs)",
 				"yaml: line 4: did not find expected key",
@@ -742,7 +742,7 @@ var _ = Describe("RenderMultiple", func() {
 				"",
 			},
 			expectedFailureLogs: []string{
-				"[Sawchain] invalid arguments",
+				sawchainPrefix, "invalid arguments",
 				"template is empty after sanitization",
 			},
 		}),
@@ -765,7 +765,7 @@ var _ = Describe("RenderMultiple", func() {
 				map[string]any{},
 			},
 			expectedFailureLogs: []string{
-				"[Sawchain] invalid template/bindings",
+				sawchainPrefix, "invalid template/bindings",
 				"failed to render template",
 				"variable not defined: $missing_binding",
 			},
@@ -795,7 +795,7 @@ var _ = Describe("RenderMultiple", func() {
 				`,
 			},
 			expectedFailureLogs: []string{
-				"[Sawchain] objects slice length must match template resource count",
+				sawchainPrefix, "objects slice length must match template resource count",
 			},
 		}),
 
@@ -825,7 +825,7 @@ var _ = Describe("RenderMultiple", func() {
 				`,
 			},
 			expectedFailureLogs: []string{
-				"[Sawchain] objects slice length must match template resource count",
+				sawchainPrefix, "objects slice length must match template resource count",
 			},
 		}),
 
@@ -854,7 +854,7 @@ var _ = Describe("RenderMultiple", func() {
 				`,
 			},
 			expectedFailureLogs: []string{
-				"[Sawchain] failed to save state to object",
+				sawchainPrefix, "failed to save state to object",
 				"destination object type *v1.Secret doesn't match source type",
 			},
 		}),
@@ -873,7 +873,7 @@ var _ = Describe("RenderMultiple", func() {
 				`,
 			},
 			expectedFailureLogs: []string{
-				"[Sawchain] failed to save state to object",
+				sawchainPrefix, "failed to save state to object",
 				"failed to convert source to typed object",
 				"no kind \"UnknownKind\" is registered for version \"unknown.group/v1\" in scheme",
 			},
@@ -1282,7 +1282,7 @@ status:
 		Entry("should fail with non-existent template file", testCase{
 			template: "non-existent.yaml",
 			expectedFailureLogs: []string{
-				"[Sawchain] invalid template/bindings",
+				sawchainPrefix, "invalid template/bindings",
 				"if using a file, ensure the file exists and the path is correct",
 			},
 		}),
@@ -1296,7 +1296,7 @@ status:
 				 badindent: fail
 				`,
 			expectedFailureLogs: []string{
-				"[Sawchain] invalid arguments",
+				sawchainPrefix, "invalid arguments",
 				"failed to sanitize template content",
 				"ensure leading whitespace is consistent and YAML is indented with spaces (not tabs)",
 				"yaml: line 4: did not find expected key",
@@ -1306,7 +1306,7 @@ status:
 		Entry("should fail with empty template", testCase{
 			template: "",
 			expectedFailureLogs: []string{
-				"[Sawchain] invalid arguments",
+				sawchainPrefix, "invalid arguments",
 				"template is empty after sanitization",
 			},
 		}),
@@ -1320,7 +1320,7 @@ status:
 				  namespace: default
 				`,
 			expectedFailureLogs: []string{
-				"[Sawchain] invalid template/bindings",
+				sawchainPrefix, "invalid template/bindings",
 				"failed to render template",
 				"variable not defined: $missing_binding",
 			},
@@ -1341,7 +1341,7 @@ status:
 				  namespace: default
 				`,
 			expectedFailureLogs: []string{
-				"[Sawchain] invalid template/bindings",
+				sawchainPrefix, "invalid template/bindings",
 				"failed to render template",
 				"variable not defined: $missing_binding",
 			},

--- a/sawchain.go
+++ b/sawchain.go
@@ -158,7 +158,7 @@ func (s *Sawchain) checkNotFoundF(ctx context.Context, obj client.Object) func()
 func (s *Sawchain) convertReturnObject(unstructuredObj unstructured.Unstructured) client.Object {
 	// Convert to typed
 	if obj, err := util.TypedFromUnstructured(s.c, unstructuredObj); err != nil {
-		// Log error and return unstructured object
+		// Log warning and return unstructured object
 		s.t.Logf("%s: %v", infoFailedConvert, err)
 		return &unstructuredObj
 	} else {

--- a/sawchain.go
+++ b/sawchain.go
@@ -16,30 +16,30 @@ import (
 )
 
 const (
-	errInvalidArgs        = "invalid arguments"
-	errInvalidTemplate    = "invalid template/bindings"
-	errObjectInsufficient = "single object insufficient for multi-resource template"
-	errObjectsWrongLength = "objects slice length must match template resource count"
+	errInvalidArgs        = "[Sawchain] invalid arguments"
+	errInvalidTemplate    = "[Sawchain] invalid template/bindings"
+	errObjectInsufficient = "[Sawchain] single object insufficient for multi-resource template"
+	errObjectsWrongLength = "[Sawchain] objects slice length must match template resource count"
 
-	errCacheNotSynced = "client cache not synced within timeout"
-	errFailedSave     = "failed to save state to object"
-	errFailedWrite    = "failed to write file"
+	errCacheNotSynced = "[Sawchain] client cache not synced within timeout"
+	errFailedSave     = "[Sawchain] failed to save state to object"
+	errFailedWrite    = "[Sawchain] failed to write file"
 
-	errFailedCreateWithObject   = "failed to create with object"
-	errFailedCreateWithTemplate = "failed to create with template"
-	errFailedDeleteWithObject   = "failed to delete with object"
-	errFailedDeleteWithTemplate = "failed to delete with template"
-	errFailedGetWithObject      = "failed to get with object"
-	errFailedGetWithTemplate    = "failed to get with template"
-	errFailedUpdateWithObject   = "failed to update with object"
-	errFailedUpdateWithTemplate = "failed to update with template"
-	errFailedMergePatch         = "failed to merge patch from template"
+	errFailedCreateWithObject   = "[Sawchain] failed to create with object"
+	errFailedCreateWithTemplate = "[Sawchain] failed to create with template"
+	errFailedDeleteWithObject   = "[Sawchain] failed to delete with object"
+	errFailedDeleteWithTemplate = "[Sawchain] failed to delete with template"
+	errFailedGetWithObject      = "[Sawchain] failed to get with object"
+	errFailedGetWithTemplate    = "[Sawchain] failed to get with template"
+	errFailedUpdateWithObject   = "[Sawchain] failed to update with object"
+	errFailedUpdateWithTemplate = "[Sawchain] failed to update with template"
+	errFailedMergePatch         = "[Sawchain] failed to merge patch from template"
 
-	errNilOpts             = "internal error: parsed options is nil"
-	errFailedMarshalObject = "internal error: failed to marshal object"
-	errCreatedMatcherIsNil = "internal error: created matcher is nil"
+	errNilOpts             = "[Sawchain] internal error: parsed options is nil"
+	errFailedMarshalObject = "[Sawchain] internal error: failed to marshal object"
+	errCreatedMatcherIsNil = "[Sawchain] internal error: created matcher is nil"
 
-	infoFailedConvert = "failed to convert return object to typed; returning unstructured instead"
+	infoFailedConvert = "[Sawchain] failed to convert return object to typed; returning unstructured instead"
 )
 
 // Sawchain provides utilities for K8s YAML-driven testing—powered by Chainsaw. It includes helpers to

--- a/sawchain.go
+++ b/sawchain.go
@@ -23,7 +23,6 @@ const (
 
 	errCacheNotSynced = "client cache not synced within timeout"
 	errFailedSave     = "failed to save state to object"
-	errFailedConvert  = "failed to convert return object to typed"
 	errFailedWrite    = "failed to write file"
 
 	errFailedCreateWithObject   = "failed to create with object"
@@ -39,6 +38,8 @@ const (
 	errNilOpts             = "internal error: parsed options is nil"
 	errFailedMarshalObject = "internal error: failed to marshal object"
 	errCreatedMatcherIsNil = "internal error: created matcher is nil"
+
+	infoFailedConvert = "failed to convert return object to typed; returning unstructured instead"
 )
 
 // Sawchain provides utilities for K8s YAML-driven testing—powered by Chainsaw. It includes helpers to
@@ -157,8 +158,8 @@ func (s *Sawchain) checkNotFoundF(ctx context.Context, obj client.Object) func()
 func (s *Sawchain) convertReturnObject(unstructuredObj unstructured.Unstructured) client.Object {
 	// Convert to typed
 	if obj, err := util.TypedFromUnstructured(s.c, unstructuredObj); err != nil {
-		// Log warning and return unstructured object
-		s.t.Logf("%s: %v", errFailedConvert, err)
+		// Log error and return unstructured object
+		s.t.Logf("%s: %v", infoFailedConvert, err)
 		return &unstructuredObj
 	} else {
 		// Return typed object

--- a/suite_test.go
+++ b/suite_test.go
@@ -18,6 +18,8 @@ import (
 const (
 	fastTimeout  = 100 * time.Millisecond
 	fastInterval = 5 * time.Millisecond
+
+	sawchainPrefix = "[Sawchain]"
 )
 
 var ctx = context.Background()

--- a/update_test.go
+++ b/update_test.go
@@ -820,7 +820,7 @@ var _ = Describe("Update", func() {
 		Entry("should fail with no arguments", testCase{
 			client: &MockClient{Client: testutil.NewStandardFakeClient()},
 			expectedFailureLogs: []string{
-				"invalid arguments",
+				"[Sawchain] invalid arguments",
 				"required argument(s) not provided: Template (string), Object (client.Object), or Objects ([]client.Object)",
 			},
 		}),
@@ -831,7 +831,7 @@ var _ = Describe("Update", func() {
 				[]string{"unexpected", "argument", "type"},
 			},
 			expectedFailureLogs: []string{
-				"invalid arguments",
+				"[Sawchain] invalid arguments",
 				"unexpected argument type: []string",
 			},
 		}),
@@ -842,7 +842,7 @@ var _ = Describe("Update", func() {
 				"non-existent.yaml",
 			},
 			expectedFailureLogs: []string{
-				"invalid template/bindings",
+				"[Sawchain] invalid template/bindings",
 				"if using a file, ensure the file exists and the path is correct",
 			},
 		}),
@@ -853,7 +853,7 @@ var _ = Describe("Update", func() {
 				`invalid: yaml: [`,
 			},
 			expectedFailureLogs: []string{
-				"invalid arguments",
+				"[Sawchain] invalid arguments",
 				"failed to sanitize template content",
 				"ensure leading whitespace is consistent and YAML is indented with spaces (not tabs)",
 				"yaml: mapping values are not allowed in this context",
@@ -872,7 +872,7 @@ var _ = Describe("Update", func() {
 				`,
 			},
 			expectedFailureLogs: []string{
-				"invalid template/bindings",
+				"[Sawchain] invalid template/bindings",
 				"failed to render template",
 				"variable not defined: $missing",
 			},
@@ -907,7 +907,7 @@ var _ = Describe("Update", func() {
 				`,
 			},
 			expectedFailureLogs: []string{
-				"objects slice length must match template resource count",
+				"[Sawchain] objects slice length must match template resource count",
 			},
 		}),
 
@@ -924,7 +924,7 @@ var _ = Describe("Update", func() {
 				},
 			},
 			expectedFailureLogs: []string{
-				"invalid arguments",
+				"[Sawchain] invalid arguments",
 				"client.Object and []client.Object arguments both provided",
 			},
 		}),
@@ -956,7 +956,7 @@ var _ = Describe("Update", func() {
 				testutil.NewConfigMap("test-cm", "default", map[string]string{"foo": "updated"}),
 			},
 			expectedFailureLogs: []string{
-				"single object insufficient for multi-resource template",
+				"[Sawchain] single object insufficient for multi-resource template",
 			},
 		}),
 
@@ -978,7 +978,7 @@ var _ = Describe("Update", func() {
 				&corev1.Secret{},
 			},
 			expectedFailureLogs: []string{
-				"failed to save state to object",
+				"[Sawchain] failed to save state to object",
 				"destination object type *v1.Secret doesn't match source type *v1.ConfigMap",
 			},
 		}),
@@ -1806,7 +1806,7 @@ var _ = Describe("UpdateAndWait", func() {
 		Entry("should fail with no arguments", testCase{
 			client: &MockClient{Client: testutil.NewStandardFakeClient()},
 			expectedFailureLogs: []string{
-				"invalid arguments",
+				"[Sawchain] invalid arguments",
 				"required argument(s) not provided: Template (string), Object (client.Object), or Objects ([]client.Object)",
 			},
 		}),
@@ -1817,7 +1817,7 @@ var _ = Describe("UpdateAndWait", func() {
 				[]string{"unexpected", "argument", "type"},
 			},
 			expectedFailureLogs: []string{
-				"invalid arguments",
+				"[Sawchain] invalid arguments",
 				"unexpected argument type: []string",
 			},
 		}),
@@ -1828,7 +1828,7 @@ var _ = Describe("UpdateAndWait", func() {
 				"non-existent.yaml",
 			},
 			expectedFailureLogs: []string{
-				"invalid template/bindings",
+				"[Sawchain] invalid template/bindings",
 				"if using a file, ensure the file exists and the path is correct",
 			},
 		}),
@@ -1839,7 +1839,7 @@ var _ = Describe("UpdateAndWait", func() {
 				`invalid: yaml: [`,
 			},
 			expectedFailureLogs: []string{
-				"invalid arguments",
+				"[Sawchain] invalid arguments",
 				"failed to sanitize template content",
 				"ensure leading whitespace is consistent and YAML is indented with spaces (not tabs)",
 				"yaml: mapping values are not allowed in this context",
@@ -1858,7 +1858,7 @@ var _ = Describe("UpdateAndWait", func() {
 				`,
 			},
 			expectedFailureLogs: []string{
-				"invalid template/bindings",
+				"[Sawchain] invalid template/bindings",
 				"failed to render template",
 				"variable not defined: $missing",
 			},
@@ -1876,6 +1876,7 @@ var _ = Describe("UpdateAndWait", func() {
 				testutil.NewConfigMap("test-cm", "default", map[string]string{"foo": "updated"}),
 			},
 			expectedFailureLogs: []string{
+				"[Sawchain] failed to update with object",
 				"simulated update failure",
 			},
 		}),
@@ -1892,6 +1893,7 @@ var _ = Describe("UpdateAndWait", func() {
 				testutil.NewConfigMap("test-cm", "default", map[string]string{"foo": "updated"}),
 			},
 			expectedFailureLogs: []string{
+				"[Sawchain] client cache not synced within timeout",
 				"simulated get failure",
 			},
 		}),
@@ -1912,6 +1914,7 @@ var _ = Describe("UpdateAndWait", func() {
 				},
 			},
 			expectedFailureLogs: []string{
+				"[Sawchain] failed to update with object",
 				"simulated update failure",
 			},
 		}),
@@ -1932,6 +1935,7 @@ var _ = Describe("UpdateAndWait", func() {
 				},
 			},
 			expectedFailureLogs: []string{
+				"[Sawchain] client cache not synced within timeout",
 				"simulated get failure",
 			},
 		}),
@@ -1965,7 +1969,7 @@ var _ = Describe("UpdateAndWait", func() {
 				`,
 			},
 			expectedFailureLogs: []string{
-				"objects slice length must match template resource count",
+				"[Sawchain] objects slice length must match template resource count",
 			},
 		}),
 
@@ -1982,7 +1986,7 @@ var _ = Describe("UpdateAndWait", func() {
 				},
 			},
 			expectedFailureLogs: []string{
-				"invalid arguments",
+				"[Sawchain] invalid arguments",
 				"client.Object and []client.Object arguments both provided",
 			},
 		}),
@@ -2014,7 +2018,7 @@ var _ = Describe("UpdateAndWait", func() {
 				testutil.NewConfigMap("test-cm", "default", map[string]string{"foo": "updated"}),
 			},
 			expectedFailureLogs: []string{
-				"single object insufficient for multi-resource template",
+				"[Sawchain] single object insufficient for multi-resource template",
 			},
 		}),
 
@@ -2036,7 +2040,7 @@ var _ = Describe("UpdateAndWait", func() {
 				&corev1.Secret{},
 			},
 			expectedFailureLogs: []string{
-				"failed to save state to object",
+				"[Sawchain] failed to save state to object",
 				"destination object type *v1.Secret doesn't match source type *v1.ConfigMap",
 			},
 		}),

--- a/update_test.go
+++ b/update_test.go
@@ -820,7 +820,7 @@ var _ = Describe("Update", func() {
 		Entry("should fail with no arguments", testCase{
 			client: &MockClient{Client: testutil.NewStandardFakeClient()},
 			expectedFailureLogs: []string{
-				"[Sawchain] invalid arguments",
+				sawchainPrefix, "invalid arguments",
 				"required argument(s) not provided: Template (string), Object (client.Object), or Objects ([]client.Object)",
 			},
 		}),
@@ -831,7 +831,7 @@ var _ = Describe("Update", func() {
 				[]string{"unexpected", "argument", "type"},
 			},
 			expectedFailureLogs: []string{
-				"[Sawchain] invalid arguments",
+				sawchainPrefix, "invalid arguments",
 				"unexpected argument type: []string",
 			},
 		}),
@@ -842,7 +842,7 @@ var _ = Describe("Update", func() {
 				"non-existent.yaml",
 			},
 			expectedFailureLogs: []string{
-				"[Sawchain] invalid template/bindings",
+				sawchainPrefix, "invalid template/bindings",
 				"if using a file, ensure the file exists and the path is correct",
 			},
 		}),
@@ -853,7 +853,7 @@ var _ = Describe("Update", func() {
 				`invalid: yaml: [`,
 			},
 			expectedFailureLogs: []string{
-				"[Sawchain] invalid arguments",
+				sawchainPrefix, "invalid arguments",
 				"failed to sanitize template content",
 				"ensure leading whitespace is consistent and YAML is indented with spaces (not tabs)",
 				"yaml: mapping values are not allowed in this context",
@@ -872,7 +872,7 @@ var _ = Describe("Update", func() {
 				`,
 			},
 			expectedFailureLogs: []string{
-				"[Sawchain] invalid template/bindings",
+				sawchainPrefix, "invalid template/bindings",
 				"failed to render template",
 				"variable not defined: $missing",
 			},
@@ -907,7 +907,7 @@ var _ = Describe("Update", func() {
 				`,
 			},
 			expectedFailureLogs: []string{
-				"[Sawchain] objects slice length must match template resource count",
+				sawchainPrefix, "objects slice length must match template resource count",
 			},
 		}),
 
@@ -924,7 +924,7 @@ var _ = Describe("Update", func() {
 				},
 			},
 			expectedFailureLogs: []string{
-				"[Sawchain] invalid arguments",
+				sawchainPrefix, "invalid arguments",
 				"client.Object and []client.Object arguments both provided",
 			},
 		}),
@@ -956,7 +956,7 @@ var _ = Describe("Update", func() {
 				testutil.NewConfigMap("test-cm", "default", map[string]string{"foo": "updated"}),
 			},
 			expectedFailureLogs: []string{
-				"[Sawchain] single object insufficient for multi-resource template",
+				sawchainPrefix, "single object insufficient for multi-resource template",
 			},
 		}),
 
@@ -978,7 +978,7 @@ var _ = Describe("Update", func() {
 				&corev1.Secret{},
 			},
 			expectedFailureLogs: []string{
-				"[Sawchain] failed to save state to object",
+				sawchainPrefix, "failed to save state to object",
 				"destination object type *v1.Secret doesn't match source type *v1.ConfigMap",
 			},
 		}),
@@ -1806,7 +1806,7 @@ var _ = Describe("UpdateAndWait", func() {
 		Entry("should fail with no arguments", testCase{
 			client: &MockClient{Client: testutil.NewStandardFakeClient()},
 			expectedFailureLogs: []string{
-				"[Sawchain] invalid arguments",
+				sawchainPrefix, "invalid arguments",
 				"required argument(s) not provided: Template (string), Object (client.Object), or Objects ([]client.Object)",
 			},
 		}),
@@ -1817,7 +1817,7 @@ var _ = Describe("UpdateAndWait", func() {
 				[]string{"unexpected", "argument", "type"},
 			},
 			expectedFailureLogs: []string{
-				"[Sawchain] invalid arguments",
+				sawchainPrefix, "invalid arguments",
 				"unexpected argument type: []string",
 			},
 		}),
@@ -1828,7 +1828,7 @@ var _ = Describe("UpdateAndWait", func() {
 				"non-existent.yaml",
 			},
 			expectedFailureLogs: []string{
-				"[Sawchain] invalid template/bindings",
+				sawchainPrefix, "invalid template/bindings",
 				"if using a file, ensure the file exists and the path is correct",
 			},
 		}),
@@ -1839,7 +1839,7 @@ var _ = Describe("UpdateAndWait", func() {
 				`invalid: yaml: [`,
 			},
 			expectedFailureLogs: []string{
-				"[Sawchain] invalid arguments",
+				sawchainPrefix, "invalid arguments",
 				"failed to sanitize template content",
 				"ensure leading whitespace is consistent and YAML is indented with spaces (not tabs)",
 				"yaml: mapping values are not allowed in this context",
@@ -1858,7 +1858,7 @@ var _ = Describe("UpdateAndWait", func() {
 				`,
 			},
 			expectedFailureLogs: []string{
-				"[Sawchain] invalid template/bindings",
+				sawchainPrefix, "invalid template/bindings",
 				"failed to render template",
 				"variable not defined: $missing",
 			},
@@ -1876,7 +1876,7 @@ var _ = Describe("UpdateAndWait", func() {
 				testutil.NewConfigMap("test-cm", "default", map[string]string{"foo": "updated"}),
 			},
 			expectedFailureLogs: []string{
-				"[Sawchain] failed to update with object",
+				sawchainPrefix, "failed to update with object",
 				"simulated update failure",
 			},
 		}),
@@ -1893,7 +1893,7 @@ var _ = Describe("UpdateAndWait", func() {
 				testutil.NewConfigMap("test-cm", "default", map[string]string{"foo": "updated"}),
 			},
 			expectedFailureLogs: []string{
-				"[Sawchain] client cache not synced within timeout",
+				sawchainPrefix, "client cache not synced within timeout",
 				"simulated get failure",
 			},
 		}),
@@ -1914,7 +1914,7 @@ var _ = Describe("UpdateAndWait", func() {
 				},
 			},
 			expectedFailureLogs: []string{
-				"[Sawchain] failed to update with object",
+				sawchainPrefix, "failed to update with object",
 				"simulated update failure",
 			},
 		}),
@@ -1935,7 +1935,7 @@ var _ = Describe("UpdateAndWait", func() {
 				},
 			},
 			expectedFailureLogs: []string{
-				"[Sawchain] client cache not synced within timeout",
+				sawchainPrefix, "client cache not synced within timeout",
 				"simulated get failure",
 			},
 		}),
@@ -1969,7 +1969,7 @@ var _ = Describe("UpdateAndWait", func() {
 				`,
 			},
 			expectedFailureLogs: []string{
-				"[Sawchain] objects slice length must match template resource count",
+				sawchainPrefix, "objects slice length must match template resource count",
 			},
 		}),
 
@@ -1986,7 +1986,7 @@ var _ = Describe("UpdateAndWait", func() {
 				},
 			},
 			expectedFailureLogs: []string{
-				"[Sawchain] invalid arguments",
+				sawchainPrefix, "invalid arguments",
 				"client.Object and []client.Object arguments both provided",
 			},
 		}),
@@ -2018,7 +2018,7 @@ var _ = Describe("UpdateAndWait", func() {
 				testutil.NewConfigMap("test-cm", "default", map[string]string{"foo": "updated"}),
 			},
 			expectedFailureLogs: []string{
-				"[Sawchain] single object insufficient for multi-resource template",
+				sawchainPrefix, "single object insufficient for multi-resource template",
 			},
 		}),
 
@@ -2040,7 +2040,7 @@ var _ = Describe("UpdateAndWait", func() {
 				&corev1.Secret{},
 			},
 			expectedFailureLogs: []string{
-				"[Sawchain] failed to save state to object",
+				sawchainPrefix, "failed to save state to object",
 				"destination object type *v1.Secret doesn't match source type *v1.ConfigMap",
 			},
 		}),


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Improved internal failure and info log messages by adding a [Sawchain] prefix for clarity and easier debugging.

- **Refactors**
  - Updated all internal error and info messages to include the [Sawchain] prefix.
  - Adjusted related tests and documentation to match the new log format.

<!-- End of auto-generated description by cubic. -->

