### PR TITLE
docs: improve usage notes

### DIFF
--- a/docs/usage-notes.md
+++ b/docs/usage-notes.md
@@ -1,6 +1,6 @@
 # Usage Notes
 
-Important details about Sawchain’s inputs, terminology, and recommended usage
+Important details about Sawchain’s terminology, inputs, and recommended usage
 
 ## General
 
@@ -9,14 +9,23 @@ should be preferred because they are easier to debug.
 
 ## Objects
 
-Although Sawchain is branded primarily for YAML-driven testing, it can also be used to write entirely struct-based tests.
+### Definition
 
-In most contexts, when structs (or "objects") are provided, they are populated to save resulting resource state for
+To Sawchain, an "object" is a Go struct representation of an actual resource that exists in K8s.
+
+For example, if you have a Deployment named "nginx" in your cluster, you can use an object to create, fetch, and assert against it in tests.
+
+### Input
+
+Although Sawchain is branded primarily for YAML-driven testing, it can also be used to write entirely object-based tests.
+
+In most contexts, when objects are provided, they are populated to save resulting resource state for
 type-safe access later in the test. This enables hybrid testing, where specs may be driven with YAML but use
 objects for more granular or logic-intensive assertions.
 
-Sawchain works with all objects implementing [client.Object](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/client#Object),
-including typed objects and [unstructured](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured#Unstructured) objects.
+Sawchain works with all objects implementing [client.Object](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/client#Object), including
+typed objects (e.g. `&corev1.Pod{}`) and [unstructured](https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured#Unstructured)
+objects (e.g. `&unstructured.Unstructured{}`).
 
 When dealing with typed objects, Sawchain uses the client [scheme](https://pkg.go.dev/k8s.io/apimachinery/pkg/runtime#Scheme)
 to perform internal type conversions.
@@ -28,8 +37,7 @@ If not possible (i.e. if internal type conversions fail), unstructured objects w
 
 ### Definition
 
-To Sawchain, a "template" is a static YAML K8s manifest or a
-[Chainsaw resource template](./chainsaw-cheatsheet.md)
+To Sawchain, a "template" is a static YAML K8s manifest or a [Chainsaw resource template](./chainsaw-cheatsheet.md)
 with optional [JMESPath](https://jmespath.site/) expressions for templating and/or assertions.
 
 Template content requirements differ depending on the context.
@@ -139,4 +147,5 @@ prefix from non-empty lines) and pruning empty documents.
 
 ### Bindings
 
-Unlike Chainsaw, Sawchain does not inject any built-in template [bindings](https://kyverno.github.io/chainsaw/latest/quick-start/bindings/) (e.g. `$namespace`) by default.
+Unlike Chainsaw, Sawchain does not inject any built-in template
+[bindings](https://kyverno.github.io/chainsaw/latest/quick-start/bindings/) (e.g. `$namespace`) by default.


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Clarified docs in docs/usage-notes.md: defined “object,” explained object-based testing, added typed/unstructured examples, and noted scheme conversion behavior. Simplified the Templates definition and link formatting to improve readability; no functional changes.

<!-- End of auto-generated description by cubic. -->

