### PR TITLE
feat: improve candidate mismatch errors

### DIFF
--- a/check_test.go
+++ b/check_test.go
@@ -659,6 +659,8 @@ var _ = Describe("Check and CheckFunc", func() {
 				`,
 			},
 			expectedReturnErrs: []string{
+				"0 of 1 candidates match expectation",
+				"Candidate #1 mismatch errors:",
 				"v1/ConfigMap/default/test-cm",
 				"data.key: Invalid value: \"value\": Expected value: \"wrong-value\"",
 				"--- expected",
@@ -693,6 +695,8 @@ var _ = Describe("Check and CheckFunc", func() {
 				`,
 			},
 			expectedReturnErrs: []string{
+				"0 of 1 candidates match expectation",
+				"Candidate #1 mismatch errors:",
 				"v1/ConfigMap/default/test-cm",
 				"data.(to_number(count) > `5`): Invalid value: false: Expected value: true",
 				"--- expected",

--- a/examples/crossplane-render-test/go.mod
+++ b/examples/crossplane-render-test/go.mod
@@ -101,7 +101,6 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.29.0 // indirect
 	go.opentelemetry.io/otel/trace v1.30.0 // indirect
 	go.uber.org/automaxprocs v1.6.0 // indirect
-	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/crypto v0.36.0 // indirect
 	golang.org/x/exp v0.0.0-20241004190924-225e2abe05e6 // indirect
 	golang.org/x/net v0.38.0 // indirect

--- a/examples/helm-install-test/go.mod
+++ b/examples/helm-install-test/go.mod
@@ -101,7 +101,6 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.29.0 // indirect
 	go.opentelemetry.io/otel/trace v1.30.0 // indirect
 	go.uber.org/automaxprocs v1.6.0 // indirect
-	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/crypto v0.36.0 // indirect
 	golang.org/x/exp v0.0.0-20241004190924-225e2abe05e6 // indirect
 	golang.org/x/net v0.38.0 // indirect

--- a/examples/helm-template-test/go.mod
+++ b/examples/helm-template-test/go.mod
@@ -102,7 +102,6 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.29.0 // indirect
 	go.opentelemetry.io/otel/trace v1.30.0 // indirect
 	go.uber.org/automaxprocs v1.6.0 // indirect
-	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/crypto v0.36.0 // indirect
 	golang.org/x/exp v0.0.0-20241004190924-225e2abe05e6 // indirect
 	golang.org/x/net v0.38.0 // indirect

--- a/examples/kubevela-integration-test/go.mod
+++ b/examples/kubevela-integration-test/go.mod
@@ -102,7 +102,6 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.29.0 // indirect
 	go.opentelemetry.io/otel/trace v1.30.0 // indirect
 	go.uber.org/automaxprocs v1.6.0 // indirect
-	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/crypto v0.36.0 // indirect
 	golang.org/x/exp v0.0.0-20241004190924-225e2abe05e6 // indirect
 	golang.org/x/net v0.38.0 // indirect

--- a/examples/vela-dry-run-test/go.mod
+++ b/examples/vela-dry-run-test/go.mod
@@ -102,7 +102,6 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.29.0 // indirect
 	go.opentelemetry.io/otel/trace v1.30.0 // indirect
 	go.uber.org/automaxprocs v1.6.0 // indirect
-	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/crypto v0.36.0 // indirect
 	golang.org/x/exp v0.0.0-20241004190924-225e2abe05e6 // indirect
 	golang.org/x/net v0.38.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/kyverno/chainsaw v0.2.12
 	github.com/onsi/ginkgo/v2 v2.23.4
 	github.com/onsi/gomega v1.37.0
-	go.uber.org/multierr v1.11.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.32.5
 	k8s.io/apimachinery v0.32.5

--- a/internal/chainsaw/chainsaw_test.go
+++ b/internal/chainsaw/chainsaw_test.go
@@ -990,6 +990,8 @@ data:
 				bindings:      map[string]any{},
 				expectedMatch: unstructured.Unstructured{},
 				expectedErrs: []string{
+					"0 of 1 candidates match expectation",
+					"Candidate #1 mismatch errors:",
 					"v1/ConfigMap/default/test-config",
 					"data.key1: Invalid value: \"wrong-value\": Expected value: \"expected-value\"",
 					"--- expected",
@@ -1027,6 +1029,8 @@ data:
 				bindings:      map[string]any{},
 				expectedMatch: unstructured.Unstructured{},
 				expectedErrs: []string{
+					"0 of 1 candidates match expectation",
+					"Candidate #1 mismatch errors:",
 					"v1/ConfigMap/default/test-config",
 					"data: Required value: field not found in the input object",
 					"--- expected",
@@ -1079,12 +1083,15 @@ data:
 				bindings:      map[string]any{},
 				expectedMatch: unstructured.Unstructured{},
 				expectedErrs: []string{
+					"0 of 2 candidates match expectation",
+					"Candidate #1 mismatch errors:",
 					"v1/ConfigMap/default/test-config-1",
 					"data.key1: Invalid value: \"wrong-value-1\": Expected value: \"expected-value\"",
 					"--- expected",
 					"+++ actual",
 					"-  key1: expected-value",
 					"+  key1: wrong-value-1",
+					"Candidate #2 mismatch errors:",
 					"v1/ConfigMap/default/test-config-2",
 					"data.key1: Invalid value: \"wrong-value-2\": Expected value: \"expected-value\"",
 					"--- expected",
@@ -1492,6 +1499,8 @@ data:
 				bindings:      map[string]any{},
 				expectedMatch: unstructured.Unstructured{},
 				expectedErrs: []string{
+					"0 of 1 candidates match expectation",
+					"Candidate #1 mismatch errors:",
 					"v1/ConfigMap/default/test-check-nomatch",
 					"data.key1: Invalid value: \"actual-value\": Expected value: \"expected-value\"",
 					"--- expected",
@@ -1703,6 +1712,8 @@ data:
 				bindings:      map[string]any{},
 				expectedMatch: unstructured.Unstructured{},
 				expectedErrs: []string{
+					"0 of 1 candidates match expectation",
+					"Candidate #1 mismatch errors:",
 					"v1/ConfigMap/default/test-check-length-fail",
 					"data.(length(value) > `1` && length(value) < `10`): Invalid value: false: Expected value: true",
 				},


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Improved mismatch error messages in Chainsaw’s Match function so failed checks clearly show how many candidates matched and why each candidate failed. Also removed the multierr dependency and simplified error aggregation.

- **New Features**
  - Show “0 of N candidates match expectation” when no match is found.
  - Add “Candidate #<n> mismatch errors:” before each candidate’s details.
  - Preserve existing resource diffs and field error messages for clarity.

- **Dependencies**
  - Removed go.uber.org/multierr from the main and example modules.

<!-- End of auto-generated description by cubic. -->

