### PR TITLE
fix: properly split YAML docs in Check

### DIFF
--- a/check.go
+++ b/check.go
@@ -2,7 +2,6 @@ package sawchain
 
 import (
 	"context"
-	"strings"
 
 	"github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -115,7 +114,8 @@ func (s *Sawchain) Check(ctx context.Context, args ...any) error {
 	s.g.Expect(options.RequireTemplate(opts)).To(gomega.Succeed(), errInvalidArgs)
 
 	// Split documents
-	documents := strings.Split(opts.Template, "---")
+	documents, err := util.SplitYAML(opts.Template)
+	s.g.Expect(err).NotTo(gomega.HaveOccurred(), errFailedSplitYAML)
 
 	// Validate objects length
 	if opts.Object != nil {
@@ -167,7 +167,8 @@ func (s *Sawchain) CheckFunc(ctx context.Context, args ...any) func() error {
 	s.g.Expect(options.RequireTemplate(opts)).To(gomega.Succeed(), errInvalidArgs)
 
 	// Split documents
-	documents := strings.Split(opts.Template, "---")
+	documents, err := util.SplitYAML(opts.Template)
+	s.g.Expect(err).NotTo(gomega.HaveOccurred(), errFailedSplitYAML)
 
 	// Validate objects length
 	if opts.Object != nil {

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -33,7 +33,7 @@ import "github.com/guidewire-oss/sawchain"
   - [func \(s \*Sawchain\) UpdateAndWait\(ctx context.Context, args ...any\)](<#Sawchain.UpdateAndWait>)
 
 <a name="Sawchain"></a>
-## type [Sawchain](<https://github.com/guidewire-oss/sawchain/blob/main/sawchain.go#L59-L64>)
+## type [Sawchain](<https://github.com/guidewire-oss/sawchain/blob/main/sawchain.go#L60-L65>)
 
 Sawchain provides utilities for K8s YAML\-driven testing—powered by Chainsaw. It includes helpers to reliably create/update/delete test resources, Gomega\-friendly APIs to simplify assertions, and more.
 
@@ -48,7 +48,7 @@ type Sawchain struct {
 ```
 
 <a name="New"></a>
-### func [New](<https://github.com/guidewire-oss/sawchain/blob/main/sawchain.go#L107>)
+### func [New](<https://github.com/guidewire-oss/sawchain/blob/main/sawchain.go#L108>)
 
 ```go
 func New(t testing.TB, c client.Client, args ...any) *Sawchain
@@ -97,7 +97,7 @@ sc := sawchain.New(t, k8sClient, "10s", "2s")
 ```
 
 <a name="NewWithGomega"></a>
-### func [NewWithGomega](<https://github.com/guidewire-oss/sawchain/blob/main/sawchain.go#L175>)
+### func [NewWithGomega](<https://github.com/guidewire-oss/sawchain/blob/main/sawchain.go#L176>)
 
 ```go
 func NewWithGomega(t testing.TB, g gomega.Gomega, c client.Client, args ...any) *Sawchain
@@ -153,7 +153,7 @@ sc := sawchain.NewWithGomega(t, g, k8sClient, "10s", "2s")
 ```
 
 <a name="Sawchain.Check"></a>
-### func \(\*Sawchain\) [Check](<https://github.com/guidewire-oss/sawchain/blob/main/check.go#L106>)
+### func \(\*Sawchain\) [Check](<https://github.com/guidewire-oss/sawchain/blob/main/check.go#L105>)
 
 ```go
 func (s *Sawchain) Check(ctx context.Context, args ...any) error

--- a/sawchain.go
+++ b/sawchain.go
@@ -45,6 +45,7 @@ const (
 
 	errNilOpts             = prefixErrInternal + "parsed options is nil"
 	errFailedMarshalObject = prefixErrInternal + "failed to marshal object"
+	errFailedSplitYAML     = prefixErrInternal + "failed to split YAML documents"
 	errCreatedMatcherIsNil = prefixErrInternal + "created matcher is nil"
 
 	infoFailedConvert = prefixInfo + "failed to convert return object to typed; returning unstructured instead"


### PR DESCRIPTION
Addresses https://github.com/guidewire-oss/sawchain/issues/33

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes multi-document YAML splitting in Check so templates are parsed correctly and not split on literal "---" inside values. Prevents false splits and related errors when using complex YAML content.

- **Bug Fixes**
  - Replace string-based splitting with util.SplitYAML using a real YAML decoder.
  - Handle separators inside quoted strings and block scalars.
  - Skip empty and comment-only documents.
  - Wire SplitYAML into Check and CheckFunc with explicit error handling.
  - Update PruneYAML to reuse SplitYAML.
  - Add comprehensive tests covering edge cases.

<sup>Written for commit 300c379b601043aa5c1a67d73a16802856898154. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

