### PR TITLE
docs: document error output

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -73,7 +73,7 @@ const (
 ```
 
 <a name="MatchAttempt"></a>
-## type [MatchAttempt](<https://github.com/guidewire-oss/sawchain/blob/main/sawchain.go#L43>)
+## type [MatchAttempt](<https://github.com/guidewire-oss/sawchain/blob/main/sawchain.go#L44>)
 
 MatchAttempt records the result of comparing one actual resource against one expected resource, including the field\-level errors found.
 
@@ -82,7 +82,7 @@ type MatchAttempt = chainsaw.MatchAttempt
 ```
 
 <a name="MatchError"></a>
-## type [MatchError](<https://github.com/guidewire-oss/sawchain/blob/main/sawchain.go#L39>)
+## type [MatchError](<https://github.com/guidewire-oss/sawchain/blob/main/sawchain.go#L40>)
 
 MatchError is a structured assertion error describing why one or more match attempts failed, exposing the attempts and their field errors for programmatic inspection. Errors returned by Check and CheckFunc unwrap to a \*MatchError via errors.As.
 
@@ -91,16 +91,16 @@ type MatchError = chainsaw.MatchError
 ```
 
 <a name="MatchMode"></a>
-## type [MatchMode](<https://github.com/guidewire-oss/sawchain/blob/main/sawchain.go#L47>)
+## type [MatchMode](<https://github.com/guidewire-oss/sawchain/blob/main/sawchain.go#L49>)
 
-MatchMode describes what varied across the attempts in a MatchError, which determines how attempts are labeled when formatted.
+MatchMode describes what varied across the attempts in a MatchError, which determines how attempts are labeled when formatted. See the MatchModeVaryActual and MatchModeVaryExpected constants for the supported modes.
 
 ```go
 type MatchMode = chainsaw.MatchMode
 ```
 
 <a name="Sawchain"></a>
-## type [Sawchain](<https://github.com/guidewire-oss/sawchain/blob/main/sawchain.go#L102-L107>)
+## type [Sawchain](<https://github.com/guidewire-oss/sawchain/blob/main/sawchain.go#L104-L109>)
 
 Sawchain provides utilities for K8s YAML\-driven testing—powered by Chainsaw. It includes helpers to reliably create/update/delete test resources, Gomega\-friendly APIs to simplify assertions, and more.
 
@@ -115,7 +115,7 @@ type Sawchain struct {
 ```
 
 <a name="New"></a>
-### func [New](<https://github.com/guidewire-oss/sawchain/blob/main/sawchain.go#L158>)
+### func [New](<https://github.com/guidewire-oss/sawchain/blob/main/sawchain.go#L160>)
 
 ```go
 func New(t testing.TB, c client.Client, args ...any) *Sawchain
@@ -172,7 +172,7 @@ sc := sawchain.New(t, k8sClient, sawchain.VerbosityVerbose)
 ```
 
 <a name="NewWithGomega"></a>
-### func [NewWithGomega](<https://github.com/guidewire-oss/sawchain/blob/main/sawchain.go#L237>)
+### func [NewWithGomega](<https://github.com/guidewire-oss/sawchain/blob/main/sawchain.go#L239>)
 
 ```go
 func NewWithGomega(t testing.TB, g gomega.Gomega, c client.Client, args ...any) *Sawchain
@@ -1873,9 +1873,9 @@ sc.UpdateAndWait(ctx, []client.Object{configMap, secret}, `
 ```
 
 <a name="Verbosity"></a>
-## type [Verbosity](<https://github.com/guidewire-oss/sawchain/blob/main/sawchain.go#L20>)
+## type [Verbosity](<https://github.com/guidewire-oss/sawchain/blob/main/sawchain.go#L21>)
 
-Verbosity controls the detail level of assertion error output and logging.
+Verbosity controls the detail level of assertion error output and logging. See the VerbosityMinimal, VerbosityNormal, and VerbosityVerbose constants for the supported levels.
 
 ```go
 type Verbosity = options.Verbosity

--- a/docs/usage-notes.md
+++ b/docs/usage-notes.md
@@ -154,3 +154,98 @@ prefix from non-empty lines) and pruning empty documents.
 
 Unlike Chainsaw, Sawchain does not inject any built-in template
 [bindings](https://kyverno.github.io/chainsaw/latest/quick-start/bindings/) (e.g., `$namespace`) by default.
+
+## Error Output
+
+When a match assertion fails, Sawchain renders a single, structured failure message. How much of it you see
+is controlled by the instance's [Verbosity](./api-reference.md#Verbosity), set when constructing Sawchain.
+
+```go
+// Detail level applies to all match failures from this instance
+sc := sawchain.New(t, k8sClient, sawchain.VerbosityVerbose)
+```
+
+The message is built from labeled sections. Which sections appear depends on the verbosity level and the
+number of comparisons performed.
+
+### Single Attempt
+
+For a single failed comparison (e.g., one resource compared against one expectation), the message details that
+one attempt. The examples below show a `ConfigMap` whose `data.version` did not match.
+
+At `VerbosityMinimal`, only the field-level errors are shown.
+
+```txt
+[ERROR]
+v1/ConfigMap/default/test-config
+* data.version: Invalid value: "v1": Expected value: "v2"
+```
+
+At `VerbosityNormal` (the default), a YAML diff of expected vs. actual is added.
+
+```txt
+[ERROR]
+--------------------------------
+v1/ConfigMap/default/test-config
+--------------------------------
+* data.version: Invalid value: "v1": Expected value: "v2"
+
+--- expected
++++ actual
+@@ -1,5 +1,5 @@
+ apiVersion: v1
+ data:
+-  version: v2
++  version: v1
+ kind: ConfigMap
+ metadata:
+```
+
+At `VerbosityVerbose`, the full expected/actual YAML, the un-rendered template, and the resolved bindings are
+added. The `[EXPECTED]`, `[ACTUAL]`, and `[TEMPLATE]` sections are each rendered as fenced YAML code blocks.
+The placeholders below stand in for that content.
+
+```txt
+[EXPECTED]
+<full expected YAML>
+
+[ACTUAL]
+<full actual YAML>
+
+[ERROR]
+<field errors + diff, as in Normal>
+
+[TEMPLATE]
+<un-rendered template content, e.g., version: ($version)>
+
+[BINDINGS]
+<resolved binding values>
+```
+
+### Multiple Attempts
+
+When several resources are compared against one expectation (or one resource against several expectation
+documents), the message reports how many comparisons were performed. At `VerbosityMinimal` and
+`VerbosityNormal`, only the best match (fewest field errors) is detailed and the rest are summarized
+one line each; at `VerbosityVerbose`, every attempt is detailed under `#N` labels.
+
+```txt
+0 of 3 attempts matched expectation; best match: v1/ConfigMap/default/cm-staging (1 field error)
+
+[ERROR #2]
+<best match detail at the current verbosity>
+
+[OTHER ATTEMPTS]
+Attempt #1: v1/ConfigMap/default/cm-dev (5 field errors)
+Attempt #3: v1/ConfigMap/default/cm-prod (3 field errors)
+```
+
+### Section Reference
+
+| Section | Appears at |
+| - | - |
+| `[ERROR]` / `[ERROR #N]` | all levels |
+| YAML diff (`--- expected` / `+++ actual`) | Normal and Verbose |
+| `[EXPECTED]` / `[ACTUAL]` (full YAML) | Verbose |
+| `[TEMPLATE]` / `[BINDINGS]` | Verbose |
+| `[OTHER ATTEMPTS]` summary | Minimal and Normal, multi-attempt only |

--- a/sawchain.go
+++ b/sawchain.go
@@ -16,7 +16,8 @@ import (
 	"github.com/guidewire-oss/sawchain/internal/util"
 )
 
-// Verbosity controls the detail level of assertion error output and logging.
+// Verbosity controls the detail level of assertion error output and logging. See the
+// VerbosityMinimal, VerbosityNormal, and VerbosityVerbose constants for the supported levels.
 type Verbosity = options.Verbosity
 
 const (
@@ -43,7 +44,8 @@ type MatchError = chainsaw.MatchError
 type MatchAttempt = chainsaw.MatchAttempt
 
 // MatchMode describes what varied across the attempts in a MatchError, which determines how
-// attempts are labeled when formatted.
+// attempts are labeled when formatted. See the MatchModeVaryActual and MatchModeVaryExpected
+// constants for the supported modes.
 type MatchMode = chainsaw.MatchMode
 
 const (


### PR DESCRIPTION
Documents https://github.com/guidewire-oss/sawchain/issues/43 / https://github.com/guidewire-oss/sawchain/issues/40 in the usage notes and adds missing cross-references from types to constants in the API reference.