### PR TITLE
fix: broken link in crossplane example

### DIFF
--- a/examples/crossplane-offline-test/README.md
+++ b/examples/crossplane-offline-test/README.md
@@ -1,7 +1,7 @@
 # Example: Crossplane Offline Verification Test
 
 This example demonstrates how Sawchain can be used to test rendering and schema validation of
-Crossplane v2 function-based [compositions](https://docs.crossplane.io/latest/concepts/compositions/)
+Crossplane v2 function-based [compositions](https://docs.crossplane.io/master/composition/compositions/)
 offline (without a K8s cluster)
 
 ## How To Run


### PR DESCRIPTION
Don't ask me why they decided to switch from `latest` to `master`. Odd choice on their part IMO but I'll fix the broken link anyway. 😛 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a broken docs link in the Crossplane offline verification example. Updates the compositions URL to the current master path so readers land on the correct page.

<sup>Written for commit 9cbe0ef336accce4af488da9f843a52a73e31939. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/guidewire-oss/sawchain/pull/57?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

